### PR TITLE
Check if the token is a string or an object before parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,12 +233,13 @@ Keycloak.prototype.getGrant = function(request, response) {
     }
   }
 
-  if (rawData) {
-    rawData = JSON.parse(rawData);
+  var grantData = rawData;
+  if (typeof(grantData)==='string') {
+    grantData = JSON.parse( grantData );
   }
 
-  if ( rawData && ! rawData.error ) {
-    var grant = this.grantManager.createGrant( JSON.stringify(rawData) );
+  if ( grantData && ! grantData.error ) {
+    var grant = this.grantManager.createGrant( JSON.stringify(grantData) );
     var self = this;
 
     return this.grantManager.ensureFreshness(grant)


### PR DESCRIPTION
disclaimer : I'm not a JS expert, fix could be nicer maybe. 

This extra check makes the nodejs adapter work when the application is configured as "bearer-only" , fix is inspired by this commit from the util project https://github.com/keycloak/keycloak-nodejs-auth-utils/commit/e4e8e98a051b46baf5247c7bd7d3e7c7c2275973 , not sure why it was not applied as well for this project at that time.

@abstractj @lholmquist it's all yours ... 

tested with KC 1.9.1 

