### PR TITLE
Add function names for better debug in express

### DIFF
--- a/middleware/admin-logout.js
+++ b/middleware/admin-logout.js
@@ -19,7 +19,7 @@ module.exports = function(keycloak, adminUrl) {
 
   url += 'k_logout';
 
-  return function(request, response, next) {
+  return function adminLogout(request, response, next) {
     if ( request.url != url ) {
       return next();
     }

--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -1,6 +1,6 @@
 
 module.exports = function(keycloak) {
-  return function(request, response, next) {
+  return function grantAttacher(request, response, next) {
     keycloak.getGrant( request, response )
       .then( function(grant) {
         request.kauth.grant = grant;

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -1,5 +1,5 @@
 module.exports = function(keycloak, logoutUrl) {
-  return function(request, response, next) {
+  return function logout(request, response, next) {
 
     if ( request.url != logoutUrl ) {
       return next();

--- a/middleware/post-auth.js
+++ b/middleware/post-auth.js
@@ -1,7 +1,7 @@
 var URL = require('url');
 
 module.exports = function(keycloak) {
-  return function(request, response, next) {
+  return function postAuth(request, response, next) {
     if ( ! request.query.auth_callback ) {
       return next();
     }

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -36,7 +36,7 @@ module.exports = function(keycloak, spec) {
     guard = simpleGuard.bind(undefined, spec);
   }
 
-  return function(request, response, next) {
+  return function protect(request, response, next) {
     if ( request.kauth && request.kauth.grant ) {
       if ( ! guard || guard( request.kauth.grant.access_token, request, response ) ) {
         return next();

--- a/middleware/setup.js
+++ b/middleware/setup.js
@@ -1,5 +1,5 @@
 
-module.exports = function(request, response, next) {
+module.exports = function setup(request, response, next) {
   request.kauth = {};
   next();
 };


### PR DESCRIPTION
This makes the middleware's name show up in the debug output fo express when using `DEBUG=express:*`. Otherwise shows up as `anonymous`.