### PR TITLE
Only send raw token to keep the cookie size as small as possible

### DIFF
--- a/stores/cookie-store.js
+++ b/stores/cookie-store.js
@@ -15,7 +15,7 @@ CookieStore.get = function(request) {
 };
 
 var store = function(request, response) {
-  response.cookie( CookieStore.TOKEN_KEY, JSON.stringify( this ) );
+  response.cookie( CookieStore.TOKEN_KEY, this.__raw );
 };
 
 var unstore = function(request, response) {


### PR DESCRIPTION
Sending the full, parsed token makes the headers too large for most reverse proxies, which end up dropping the response. By sending only the base64'd token, the cookie size is kept at a small enough size to be sent through.