### PR TITLE
Use token.hasRole to check for roles of other apps

### DIFF
--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -16,14 +16,7 @@ function forceLogin(keycloak, request, response) {
 }
 
 function simpleGuard(role,token) {
-  if ( role.indexOf( "app:" ) === 0 ) {
-    return token.hasApplicationRole( role.substring( 4 ) );
-  }
-  if ( role.indexOf( "realm:" ) === 0 ) {
-    return token.hasRealmRole( role.substring( 6 ) );
-  }
-
-  return false;
+  return token.hasRole(role);
 }
 
 module.exports = function(keycloak, spec) {


### PR DESCRIPTION
This allows using `<appname>:<role_name>`. Note that it might break for those that use `app:<role_name>`.