### PR TITLE
Remove store.getId

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,7 @@ Keycloak.prototype.getGrantFromCode = function(code, request, response) {
     throw new Error( "Cannot exchange code for grant in bearer-only mode" );
   }
 
-  var sessionId = this.stores[1].getId( request );
+  var sessionId = request.session.id;
 
   var self = this;
   return this.grantManager.obtainFromCode( request, code, sessionId )

--- a/stores/session-store.js
+++ b/stores/session-store.js
@@ -5,10 +5,6 @@ function SessionStore(store) {
 
 SessionStore.TOKEN_KEY = 'keycloak-token';
 
-SessionStore.prototype.getId = function(request) {
-  return request.session.id;
-};
-
 SessionStore.prototype.get = function(request) {
   return request.session[ SessionStore.TOKEN_KEY ];
 };


### PR DESCRIPTION
`store.getId` isn't implemented in cookie store, leading to a crash when logging in. I'm not really sure what its use is anyway, so I figured I could probably just delete it...