### PR TITLE
Don't crash in forceLogin when session is unavailable

### DIFF
--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -8,7 +8,9 @@ function forceLogin(keycloak, request, response) {
 
   var redirectUrl = protocol + '://' + host + ( port === '' ? '' : ':' + port ) + request.url + '?auth_callback=1';
 
-  request.session.auth_redirect_uri = redirectUrl;
+  if ( request.session ) {
+    request.session.auth_redirect_uri = redirectUrl;
+  }
 
   var uuid = UUID();
   var loginURL = keycloak.loginUrl( uuid, redirectUrl );


### PR DESCRIPTION
This fixes the following error if the express-session middleware is not in use.
```
TypeError: Cannot set property 'auth_redirect_uri' of undefined
    at forceLogin (/home/n-code/api-demo/node_modules/keycloak-connect/middleware/protect.js:11:37)
    at protect (/home/n-code/api-demo/node_modules/keycloak-connect/middleware/protect.js:44:7)
    at Layer.handle [as handle_request] (/home/n-code/api-demo/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/n-code/api-demo/node_modules/express/lib/router/route.js:131:13)
```