### PR TITLE
removed arrow function expression for store

### DIFF
--- a/stores/cookie-store.js
+++ b/stores/cookie-store.js
@@ -30,7 +30,7 @@ CookieStore.get = (request) => {
   }
 };
 
-let store = (request, response) => {
+let store = function(request, response) {
   response.cookie(CookieStore.TOKEN_KEY, this.__raw);
 };
 

--- a/stores/session-store.js
+++ b/stores/session-store.js
@@ -36,7 +36,7 @@ SessionStore.prototype.clear = (sessionId) => {
   });
 };
 
-let store = (request, response) => {
+let store = function(request, response) {
   request.session[SessionStore.TOKEN_KEY] = this.__raw;
 };
 


### PR DESCRIPTION
When using fat arrows - "this" does not bind to grant, otherwise inline within wrap, i.e., this.__raw, becomes grant._raw.