### PR TITLE
[KEYCLOAK-3324] - Node.js adapter : ensure the initial OIDC authenticationRequest contains scope=openid

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
   "author": "Roman Jurkov <winfinit@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "keycloak-connect": "0.2.0",
+    "keycloak-connect": "file:../",
 	  "hogan-express": "*",
 	  "express": "*",
 	  "express-session": "*"

--- a/index.js
+++ b/index.js
@@ -301,6 +301,7 @@ Keycloak.prototype.loginUrl = function (uuid, redirectUrl) {
   '?client_id=' + encodeURIComponent(this.config.clientId) +
   '&state=' + encodeURIComponent(uuid) +
   '&redirect_uri=' + encodeURIComponent(redirectUrl) +
+  '&scope=openid' +
   '&response_type=code';
 };
 


### PR DESCRIPTION
@lance @lholmquist could you please review when you get the chance?

Instructions to test:

1. git clone https://github.com/keycloak/keycloak && cd keycloak
2. mvn clean install -DskipTests=true && mvn -f testsuite/integration/pom.xml exec:java -Pkeycloak-server
3. Import the realm configuration from examples folder
4. run our example