### PR TITLE
registering the unprotected endpoint before registering the KC middle…

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -10,6 +10,12 @@ app.set('view engine', 'html');
 app.set('views', require('path').join(__dirname, '/view'));
 app.engine('html', hogan);
 
+// A normal un-protected public URL.
+
+app.get('/', function (req, res) {
+  res.render('index');
+});
+
 // Create a session-store to be used by both the express-session
 // middleware and the keycloak middleware.
 
@@ -45,12 +51,6 @@ app.use(keycloak.middleware({
   logout: '/logout',
   admin: '/'
 }));
-
-// A normal un-protected public URL.
-
-app.get('/', function (req, res) {
-  res.render('index');
-});
 
 app.get('/login', keycloak.protect(), function (req, res) {
   res.render('index', {


### PR DESCRIPTION
…ware

i've moved the registration of the unprotected endpoint '/' to be before any of the KC middleware gets added.  This way none of the KC functions will be called when accessing the '/' endpoint, since it is unprotected and there would be no need for any KC functions to be called.

@abstractj mind taking a look.  this is more of a design issue than anything, so not to important :)