### PR TITLE
KEYCLOAK-3384: Fix login redirect URL generation

### DIFF
--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -22,8 +22,9 @@ function forceLogin (keycloak, request, response) {
   let headerHost = request.headers.host.split(':');
   let port = headerHost[1] || '';
   let protocol = request.protocol;
+  let hasQuery = ~(request.originalUrl || request.url).indexOf('?');
 
-  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + (request.originalUrl || request.url) + '?auth_callback=1';
+  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + (request.originalUrl || request.url) + (hasQuery ? '&' : '?') + 'auth_callback=1';
 
   if (request.session) {
     request.session.auth_redirect_uri = redirectUrl;

--- a/test/keycloak-connect-test.js
+++ b/test/keycloak-connect-test.js
@@ -117,6 +117,32 @@ test('Should test protected route.', t => {
     });
 });
 
+test('Should add auth_callback as a new query string to original request without a query string.', t => {
+  request(app)
+      .get('/login')
+      .end((err, res) => {
+        if (err) {
+          console.log(err);
+        }
+        t.equal(res.headers.location.indexOf('%3Fauth_callback%3D1&') > 0, true);
+        t.equal(res.statusCode, 302);
+        t.end();
+      });
+});
+
+test('Should append auth_callback to original request with existing query string.', t => {
+  request(app)
+        .get('/login?foo=bar')
+        .end((err, res) => {
+          if (err) {
+            console.log(err);
+          }
+          t.equal(res.headers.location.indexOf('%26auth_callback%3D1') > 0, true);
+          t.equal(res.statusCode, 302);
+          t.end();
+        });
+});
+
 test('Should verify logout feature.', t => {
   request(app)
     .get('/logout')


### PR DESCRIPTION
Check if original request already contains a query string and append auth_callback=1 to existing query string if one exists; add query string otherwise. Fixes [KEYCLOAK-3384][0].

[0]: https://issues.jboss.org/browse/KEYCLOAK-3384