### PR TITLE
KEYCLOAK-3387: Add redirect to login function

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ for each section:
     }
 
     app.get( '/:section/:page', keycloak.protect( protectBySection ), sectionHandler );
+    
+### Advanced Login Configuration
+
+By default, all unauthorized requests will be redirected to the Keycloak login
+page unless your client is bearer-only. However, a confidential or public client
+may host both browsable and API endpoints. To prevent redirects on unauthenticated
+API requests and instead return an HTTP 401, you can override the `redirectToLogin` 
+function.
+
+For example, this override checks if the url contains /api/ and disables login
+redirects:
+
+	Keycloak.prototype.redirectToLogin = function(req) {
+      var apiReqMatcher = /\/api\//i;
+      return !apiReqMatcher.test(req.originalUrl || req.url);
+    };
 
 ## Additional URLs
 

--- a/index.js
+++ b/index.js
@@ -322,4 +322,8 @@ Keycloak.prototype.getAccount = function (token) {
   return this.grantManager.getAccount(token);
 };
 
+Keycloak.prototype.redirectToLogin = function (request) {
+  return !this.config.bearerOnly;
+};
+
 module.exports = Keycloak;

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -57,10 +57,10 @@ module.exports = function (keycloak, spec) {
       return keycloak.accessDenied(request, response, next);
     }
 
-    if (keycloak.config.bearerOnly) {
-      return keycloak.accessDenied(request, response, next);
-    } else {
+    if (keycloak.redirectToLogin(request)) {
       forceLogin(keycloak, request, response);
+    } else {
+      return keycloak.accessDenied(request, response, next);
     }
   };
 };


### PR DESCRIPTION
Add an overridable function, Keycloak.prototype.redirectToLogin(), to determine if an unauthorized request should be redirected to Keycloak for login or if an access denied error should be returned.