### PR TITLE
KEYCLOAK-3516 Better test organization.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 node_modules/
 keycloak-*
 !keycloak-connect-test.js
+!keycloak-object-test.js
 coverage

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 tests: lint
-	npm test
+	npm run test
 	npm run coverage
 
 lint: node_modules

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "semistandard",
     "coverage": "./node_modules/.bin/istanbul cover tape -- test/**.js",
     "prepublish": "nsp check",
-    "test": "node test/*.js",
+    "test": "tape test/*.js test/**/*.js",
     "docs": "jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./middleware/*.js stores/*.js"
   },
   "keywords": [

--- a/test/keycloak-connect-test.js
+++ b/test/keycloak-connect-test.js
@@ -18,7 +18,6 @@
 
 const test = require('tape');
 const Keycloak = require('../index');
-const UUID = require('../uuid');
 const express = require('express');
 const session = require('express-session');
 const request = require('supertest');
@@ -68,27 +67,6 @@ test('setup', t => {
     res.json(JSON.stringify(JSON.parse(req.session['keycloak-token'])));
   });
 
-  t.end();
-});
-
-test('Should verify the realm name of the config object.', t => {
-  t.equal(kc.config.realm, 'test-realm');
-  t.end();
-});
-
-test('Should verify if login URL has the configured realm.', t => {
-  t.equal(kc.loginUrl().indexOf(kc.config.realm) > 0, true);
-  t.end();
-});
-
-test('Should verify if logout URL has the configured realm.', t => {
-  t.equal(kc.logoutUrl().indexOf(kc.config.realm) > 0, true);
-  t.end();
-});
-
-test('Should generate a correct UUID.', t => {
-  const rgx = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-  t.equal(rgx.test(UUID()), true);
   t.end();
 });
 
@@ -168,11 +146,6 @@ test('Should verify custom logout.', t => {
       t.equal(res.statusCode, 302);
       t.end();
     });
-});
-
-test('Should produce correct account url.', t => {
-  t.equal(kc.accountUrl(), 'http://localhost:8080/auth/realms/test-realm/account');
-  t.end();
 });
 
 test('Should call complain after logout.', t => {

--- a/test/unit/keycloak-object-test.js
+++ b/test/unit/keycloak-object-test.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Red Hat Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+'use strict';
+
+const test = require('tape');
+const Keycloak = require('../../index');
+const UUID = require('../../uuid');
+const session = require('express-session');
+
+let kc = null;
+
+test('setup', t => {
+  let kcConfig = {
+    'realm': 'test-realm',
+    'realm-public-key': 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB',
+    'auth-server-url': 'http://localhost:8080/auth',
+    'ssl-required': 'external',
+    'resource': 'nodejs-connect',
+    'public-client': true
+  };
+
+  let memoryStore = new session.MemoryStore();
+  kc = new Keycloak({store: memoryStore}, kcConfig);
+  t.end();
+});
+
+test('Should verify the realm name of the config object.', t => {
+  t.equal(kc.config.realm, 'test-realm');
+  t.end();
+});
+
+test('Should verify if login URL has the configured realm.', t => {
+  t.equal(kc.loginUrl().indexOf(kc.config.realm) > 0, true);
+  t.end();
+});
+
+test('Should verify if logout URL has the configured realm.', t => {
+  t.equal(kc.logoutUrl().indexOf(kc.config.realm) > 0, true);
+  t.end();
+});
+
+test('Should generate a correct UUID.', t => {
+  const rgx = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+  t.equal(rgx.test(UUID()), true);
+  t.end();
+});
+
+test('Should produce correct account url.', t => {
+  t.equal(kc.accountUrl(), 'http://localhost:8080/auth/realms/test-realm/account');
+  t.end();
+});


### PR DESCRIPTION
We need to move unit tests related to
keycloak javascript object toanother
directory:

tests/unit/keycloak-object-test.js

This will make things more clear.