### PR TITLE
Always use the latest version of Keycloak

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "keycloak-auth-utils": "2.4.0"
+    "keycloak-auth-utils": "latest"
   },
   "bundledDependencies": [
     "keycloak-auth-utils"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export VERSION="2.4.0.Final"
+export VERSION=`curl -s http://www.keycloak.org | grep -i version | head -n1 | grep -o "'.*'" | sed -e "s/'//g"`
 export KEYCLOAK="keycloak-${VERSION}"


### PR DESCRIPTION
@sebastienblanc this prevents us the annoying task of having to update our integration tests and auth-utils, everything we get a new release. Let me know what do you think.

@vmuzikar I tested this change locally, but let me know if somehow this is going to affect you.