### PR TITLE
KEYCLOAK-3871 : add key rotation support

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,14 +249,14 @@ Keycloak.prototype.getGrant = function (request, response) {
   }
 
   if (grantData && !grantData.error) {
-    var grant = this.grantManager.createGrant(JSON.stringify(grantData));
     var self = this;
-
-    return this.grantManager.ensureFreshness(grant)
-      .then(grant => {
-        self.storeGrant(grant, request, response);
-        return grant;
-      });
+    return this.grantManager.createGrant(JSON.stringify(grantData))
+    .then(grant => { return this.grantManager.ensureFreshness(grant); })
+    .then(grant => {
+      self.storeGrant(grant, request, response);
+      return grant;
+    })
+    .catch(() => { return Promise.reject(); });
   }
 
   return Promise.reject();

--- a/test/unit/keycloak-object-test.js
+++ b/test/unit/keycloak-object-test.js
@@ -26,7 +26,6 @@ let kc = null;
 test('setup', t => {
   let kcConfig = {
     'realm': 'test-realm',
-    'realm-public-key': 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB',
     'auth-server-url': 'http://localhost:8080/auth',
     'ssl-required': 'external',
     'resource': 'nodejs-connect',


### PR DESCRIPTION
:warning: This PR is linked with https://github.com/keycloak/keycloak-nodejs-auth-utils/pull/41 and integrations tests will probably fail on travis since it needs the changes of `keycloak-nodejs-auth-utils` . But locally and updating your package.json to use  https://github.com/keycloak/keycloak-nodejs-auth-utils/pull/41 as dependencies the tests should pass.

@abstractj Do you mind reviewing ? 