### PR TITLE
Do not force strict mode in javascript files

### DIFF
--- a/middleware/admin.js
+++ b/middleware/admin.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 function Admin (keycloak, url) {
   this._keycloak = keycloak;

--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 module.exports = function (keycloak) {
   return function grantAttacher (request, response, next) {

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 module.exports = function (keycloak, logoutUrl) {
   return function logout (request, response, next) {

--- a/middleware/post-auth.js
+++ b/middleware/post-auth.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 const URL = require('url');
 

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 const UUID = require('./../uuid');
 

--- a/middleware/setup.js
+++ b/middleware/setup.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 module.exports = function setup (request, response, next) {
   request.kauth = {};

--- a/stores/bearer-store.js
+++ b/stores/bearer-store.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 let BearerStore = {};
 

--- a/stores/cookie-store.js
+++ b/stores/cookie-store.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 let CookieStore = {};
 

--- a/stores/session-store.js
+++ b/stores/session-store.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 function SessionStore (store) {
   this.store = store;

--- a/test/app-fixture.js
+++ b/test/app-fixture.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const Keycloak = require('../index');
 const express = require('express');

--- a/test/keycloak-connect-test.js
+++ b/test/keycloak-connect-test.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-'use strict';
+
 
 const test = require('tape');
 const roi = require('roi');

--- a/test/unit/keycloak-object-test.js
+++ b/test/unit/keycloak-object-test.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-'use strict';
+
 
 const test = require('tape');
 const Keycloak = require('../../index');

--- a/uuid.js
+++ b/uuid.js
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-'use strict';
+
 
 module.exports = function () {
   let s = [];


### PR DESCRIPTION
You can use --use_strict switch from Node (0.10+) and latest releases
(9.5+ tested) have it on by default.

See issue KEYCLOAK-4387