### PR TITLE
Allow usage behind load balancer

### DIFF
--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -30,7 +30,8 @@ module.exports = function (keycloak, logoutUrl) {
     let host = request.hostname;
     let headerHost = request.headers.host.split(':');
     let port = headerHost[1] || '';
-    let redirectUrl = request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
+    let protocol = request.headers['x-forwarded-proto'] || request.protocol;
+    let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
     let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl);
 
     response.redirect(keycloakLogoutUrl);

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -21,7 +21,7 @@ function forceLogin (keycloak, request, response) {
   let host = request.hostname;
   let headerHost = request.headers.host.split(':');
   let port = headerHost[1] || '';
-  let protocol = request.protocol;
+  let protocol = request.headers['x-forwarded-proto'] || request.protocol;
   let hasQuery = ~(request.originalUrl || request.url).indexOf('?');
 
   let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + (request.originalUrl || request.url) + (hasQuery ? '&' : '?') + 'auth_callback=1';


### PR DESCRIPTION
This allows a nodejs application running behind a load balancer (with ssl termination) to still negotiate the proper protocol to use with the keycloak backend.