### PR TITLE
Switch to development version of keycloak-auth-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "keycloak-auth-utils": "3.1.0"
+    "keycloak-auth-utils": "keycloak/keycloak-nodejs-auth-utils"
   },
   "bundledDependencies": [
     "keycloak-auth-utils"


### PR DESCRIPTION
For further releases keycloak-bot will automatically update `package.json` file with the latest release of auth-utils before the release and after will be switched to the development version back again.