### PR TITLE
Add external-url configuration settting

### DIFF
--- a/middleware/auth-utils/config.js
+++ b/middleware/auth-utils/config.js
@@ -161,6 +161,12 @@ Config.prototype.configure = function configure (config) {
     }
     this.publicKey += '-----END PUBLIC KEY-----\n';
   }
+
+  /**
+   * External URL of the server. Only needed if behind a reverse-proxy.
+   * @type {String}
+   */
+  this.externalUrl = resolveValue(config['external-url'] || config.externalUrl);
 };
 
 module.exports = Config;

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -24,7 +24,8 @@ function forceLogin (keycloak, request, response) {
   let protocol = request.protocol;
   let hasQuery = ~(request.originalUrl || request.url).indexOf('?');
 
-  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + (request.originalUrl || request.url) + (hasQuery ? '&' : '?') + 'auth_callback=1';
+  let serverUrl = keycloak.config.externalUrl || protocol + '://' + host + (port === '' ? '' : ':' + port);
+  let redirectUrl = serverUrl + (request.originalUrl || request.url) + (hasQuery ? '&' : '?') + 'auth_callback=1';
 
   if (request.session) {
     request.session.auth_redirect_uri = redirectUrl;


### PR DESCRIPTION
For https://issues.jboss.org/browse/KEYCLOAK-5954.

This setting makes it possible to override the scheme/hostname/port of the redirection. Very useful if your server is behind a reverse proxy.