### PR TITLE
[KEYCLOAK-4162] Multi-tenancy support

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,11 +68,13 @@ function Keycloak (config, keycloakConfig) {
   const configs = Array.isArray(keycloakConfig) ? keycloakConfig.map(kcRealmConfig => new Config(kcRealmConfig)) : [new Config(keycloakConfig)];
 
   // Add the custom scope value
-  configs.forEach(realmConfig => realmConfig.scope = config.scope);
+  configs.forEach(realmConfig => {
+    realmConfig.scope = config.scope;
+  });
 
-  this.configs = configs.reduce((previous, realmConfig) => Object.assign(previous, {[realmConfig.realm] : realmConfig}), {});
+  this.configs = configs.reduce((previous, realmConfig) => Object.assign(previous, {[realmConfig.realm]: realmConfig}), {});
 
-  this.grantManagers = configs.reduce((previous, realmConfig) => Object.assign(previous, {[realmConfig.realm] : new GrantManager(realmConfig)}), {});
+  this.grantManagers = configs.reduce((previous, realmConfig) => Object.assign(previous, {[realmConfig.realm]: new GrantManager(realmConfig)}), {});
 
   this.stores = [ BearerStore ];
 

--- a/index.js
+++ b/index.js
@@ -56,23 +56,25 @@ var Protect = require('./middleware/protect');
  *
  */
 function Keycloak (config, keycloakConfig) {
-  // If keycloakConfig is null, Config() will search for `keycloak.json`.
-  this.config = new Config(keycloakConfig);
-
-  this.grantManager = new GrantManager(this.config);
-
-  this.stores = [ BearerStore ];
-
   if (!config) {
     throw new Error('Adapter configuration must be provided.');
   }
 
-  // Add the custom scope value
-  this.config.scope = config.scope;
-
   if (config && config.store && config.cookies) {
     throw new Error('Either `store` or `cookies` may be set, but not both');
   }
+
+  // If keycloakConfig is null, Config() will search for `keycloak.json`.
+  const configs = Array.isArray(keycloakConfig) ? keycloakConfig.map(kcRealmConfig => new Config(kcRealmConfig)) : [new Config(keycloakConfig)];
+
+  // Add the custom scope value
+  configs.forEach(realmConfig => realmConfig.scope = config.scope);
+
+  this.configs = configs.reduce((previous, realmConfig) => Object.assign(previous, {[realmConfig.realm] : realmConfig}), {});
+
+  this.grantManagers = configs.reduce((previous, realmConfig) => Object.assign(previous, {[realmConfig.realm] : new GrantManager(realmConfig)}), {});
+
+  this.stores = [ BearerStore ];
 
   if (config && config.store) {
     this.stores.push(new SessionStore(config.store));
@@ -99,6 +101,7 @@ function Keycloak (config, keycloakConfig) {
  *
  *  - `logout` URL for logging a user out. Defaults to `/logout`.
  *  - `admin` Root URL for Keycloak admin callbacks.  Defaults to `/`.
+ *  - `realmResolver` Lambda or Function: request => string. Extract the realm name from the request (multitenant only).
  *
  * @param {Object} options Optional options for specifying details.
  */
@@ -110,9 +113,15 @@ Keycloak.prototype.middleware = function (options) {
   options.logout = options.logout || '/logout';
   options.admin = options.admin || '/';
 
+  const resolver = Object.keys(this.configs).length === 1 ? () => this.configs[Object.keys(this.configs)[0]].realm : options.realmResolver;
+
+  if (!resolver) {
+    throw new Error('Realm resolver must be provided for Multi-tenancy.');
+  }
+
   var middlewares = [];
 
-  middlewares.push(Setup);
+  middlewares.push(Setup(resolver));
   middlewares.push(PostAuth(this));
   middlewares.push(Admin(this, options.admin));
   middlewares.push(GrantAttacher(this));
@@ -252,17 +261,25 @@ Keycloak.prototype.getGrant = function (request, response) {
   }
 
   if (grantData && !grantData.error) {
-    var self = this;
-    return this.grantManager.createGrant(JSON.stringify(grantData))
-    .then(grant => { return this.grantManager.ensureFreshness(grant); })
+    const grantManager = this.getGrantManager(request);
+    return grantManager.createGrant(JSON.stringify(grantData))
+    .then(grant => grantManager.ensureFreshness(grant))
     .then(grant => {
-      self.storeGrant(grant, request, response);
+      this.storeGrant(grant, request, response);
       return grant;
     })
-    .catch(() => { return Promise.reject(); });
+    .catch(() => Promise.reject());
   }
 
   return Promise.reject();
+};
+
+Keycloak.prototype.getGrantManager = function (request) {
+  return this.grantManagers[request.kauth.realmName];
+};
+
+Keycloak.prototype.getConfig = function (request) {
+  return this.configs[request.kauth.realmName];
 };
 
 Keycloak.prototype.storeGrant = function (grant, request, response) {
@@ -298,39 +315,40 @@ Keycloak.prototype.getGrantFromCode = function (code, request, response) {
   var sessionId = request.session.id;
 
   var self = this;
-  return this.grantManager.obtainFromCode(request, code, sessionId)
+  return this.getGrantManager(request).obtainFromCode(request, code, sessionId)
     .then(function (grant) {
       self.storeGrant(grant, request, response);
       return grant;
     });
 };
 
-Keycloak.prototype.loginUrl = function (uuid, redirectUrl) {
-  return this.config.realmUrl +
+Keycloak.prototype.loginUrl = function (request, uuid, redirectUrl) {
+  const config = this.getConfig(request);
+  return config.realmUrl +
   '/protocol/openid-connect/auth' +
-  '?client_id=' + encodeURIComponent(this.config.clientId) +
+  '?client_id=' + encodeURIComponent(config.clientId) +
   '&state=' + encodeURIComponent(uuid) +
   '&redirect_uri=' + encodeURIComponent(redirectUrl) +
-  '&scope=' + encodeURIComponent(this.config.scope ? 'openid ' + this.config.scope : 'openid') +
+  '&scope=' + encodeURIComponent(config.scope ? 'openid ' + config.scope : 'openid') +
   '&response_type=code';
 };
 
-Keycloak.prototype.logoutUrl = function (redirectUrl) {
-  return this.config.realmUrl +
+Keycloak.prototype.logoutUrl = function (request, redirectUrl) {
+  return this.getConfig(request).realmUrl +
   '/protocol/openid-connect/logout' +
   '?redirect_uri=' + encodeURIComponent(redirectUrl);
 };
 
-Keycloak.prototype.accountUrl = function () {
-  return this.config.realmUrl + '/account';
+Keycloak.prototype.accountUrl = function (request) {
+  return this.getConfig(request).realmUrl + '/account';
 };
 
-Keycloak.prototype.getAccount = function (token) {
-  return this.grantManager.getAccount(token);
+Keycloak.prototype.getAccount = function (token, request) {
+  return this.getGrantManager(request).getAccount(token);
 };
 
 Keycloak.prototype.redirectToLogin = function (request) {
-  return !this.config.bearerOnly;
+  return !this.getConfig(request).bearerOnly;
 };
 
 module.exports = Keycloak;

--- a/middleware/admin.js
+++ b/middleware/admin.js
@@ -40,7 +40,7 @@ function adminLogout (request, response, keycloak) {
     if (payload.action === 'LOGOUT') {
       let sessionIDs = payload.adapterSessionIds;
       if (!sessionIDs) {
-        keycloak.grantManager.notBefore = payload.notBefore;
+        keycloak.getGrantManager(request).notBefore = payload.notBefore;
         response.send('ok');
         return;
       }
@@ -71,7 +71,7 @@ function adminNotBefore (request, response, keycloak) {
     let parts = data.split('.');
     let payload = JSON.parse(new Buffer(parts[1], 'base64').toString());
     if (payload.action === 'PUSH_NOT_BEFORE') {
-      keycloak.grantManager.notBefore = payload.notBefore;
+      keycloak.getGrantManager(request).notBefore = payload.notBefore;
       response.send('ok');
     }
   });

--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -15,9 +15,9 @@
  */
 'use strict';
 
-module.exports = function (keycloak, resolver) {
+module.exports = function (keycloak) {
   return function grantAttacher (request, response, next) {
-    keycloak.getGrant(request, response, resolver)
+    keycloak.getGrant(request, response)
       .then(grant => {
         request.kauth.grant = grant;
       })

--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -15,9 +15,9 @@
  */
 'use strict';
 
-module.exports = function (keycloak) {
+module.exports = function (keycloak, resolver) {
   return function grantAttacher (request, response, next) {
-    keycloak.getGrant(request, response)
+    keycloak.getGrant(request, response, resolver)
       .then(grant => {
         request.kauth.grant = grant;
       })

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -31,7 +31,7 @@ module.exports = function (keycloak, logoutUrl) {
     let headerHost = request.headers.host.split(':');
     let port = headerHost[1] || '';
     let redirectUrl = request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
-    let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl);
+    let keycloakLogoutUrl = keycloak.logoutUrl(request, redirectUrl);
 
     response.redirect(keycloakLogoutUrl);
   };

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -31,7 +31,7 @@ function forceLogin (keycloak, request, response) {
   }
 
   let uuid = UUID();
-  let loginURL = keycloak.loginUrl(uuid, redirectUrl);
+  let loginURL = keycloak.loginUrl(request, uuid, redirectUrl);
   response.redirect(loginURL);
 }
 

--- a/middleware/setup.js
+++ b/middleware/setup.js
@@ -1,23 +1,11 @@
-/*
- * Copyright 2016 Red Hat Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 'use strict';
 
 module.exports = function (resolver) {
   return function setup (request, response, next) {
     request.kauth = {realmName: resolver(request)};
+    if (!request.kauth.realmName) {
+      throw new Error('Realm name cannot be resolved');
+    }
     next();
   };
 };

--- a/middleware/setup.js
+++ b/middleware/setup.js
@@ -17,7 +17,6 @@
 
 module.exports = function (resolver) {
   return function setup (request, response, next) {
-    console.log(resolver(request));
     request.kauth = {realmName: resolver(request)};
     next();
   };

--- a/middleware/setup.js
+++ b/middleware/setup.js
@@ -15,7 +15,10 @@
  */
 'use strict';
 
-module.exports = function setup (request, response, next) {
-  request.kauth = {};
-  next();
+module.exports = function (resolver) {
+  return function setup (request, response, next) {
+    console.log(resolver(request));
+    request.kauth = {realmName: resolver(request)};
+    next();
+  };
 };

--- a/test/unit/keycloak-object-test.js
+++ b/test/unit/keycloak-object-test.js
@@ -46,27 +46,27 @@ test('setup', t => {
 });
 
 test('Should verify the realm name of the config object.', t => {
-  t.equal(kc.config.realm, 'test-realm');
+  t.equal(kc.configs['test-realm'].realm, 'test-realm');
   t.end();
 });
 
 test('Should verify if login URL has the configured realm.', t => {
-  t.equal(kc.loginUrl().indexOf(kc.config.realm) > 0, true);
+  t.equal(kc.loginUrl({kauth: {realmName: 'test-realm'}}).indexOf(kc.configs['test-realm'].realm) > 0, true);
   t.end();
 });
 
 test('Should verify if login URL has the custom scope value.', t => {
-  t.equal(kc.loginUrl().indexOf(kc.config.scope) > 0, true);
+  t.equal(kc.loginUrl({kauth: {realmName: 'test-realm'}}).indexOf(kc.configs['test-realm'].scope) > 0, true);
   t.end();
 });
 
 test('Should verify if login URL has the default scope value.', t => {
-  t.equal(kc.loginUrl().indexOf('openid') > 0, true);
+  t.equal(kc.loginUrl({kauth: {realmName: 'test-realm'}}).indexOf('openid') > 0, true);
   t.end();
 });
 
 test('Should verify if logout URL has the configured realm.', t => {
-  t.equal(kc.logoutUrl().indexOf(kc.config.realm) > 0, true);
+  t.equal(kc.logoutUrl({kauth: {realmName: 'test-realm'}}).indexOf(kc.configs['test-realm'].realm) > 0, true);
   t.end();
 });
 
@@ -77,6 +77,6 @@ test('Should generate a correct UUID.', t => {
 });
 
 test('Should produce correct account url.', t => {
-  t.equal(kc.accountUrl(), 'http://localhost:8080/auth/realms/test-realm/account');
+  t.equal(kc.accountUrl({kauth: {realmName: 'test-realm'}}), 'http://localhost:8080/auth/realms/test-realm/account');
   t.end();
 });


### PR DESCRIPTION
- Enable to pass an array of config, one per realm
- When using multiple configs, a resolver that fetch the realm name from the request needs to be provide
- Retrocompatible, it still works as usual