### PR TITLE
fix a bug with rhel sso 7.1 refresh token call on ensureFreshness

### DIFF
--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -156,7 +156,7 @@ GrantManager.prototype.ensureFreshness = function ensureFreshness (grant, callba
   const params = {
     grant_type: 'refresh_token',
     refresh_token: grant.refresh_token.token,
-    client_id: this.clientId,
+    client_id: this.clientId
   };
   const handler = refreshHandler(this, grant);
   const options = postOptions(this);

--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -155,7 +155,8 @@ GrantManager.prototype.ensureFreshness = function ensureFreshness (grant, callba
 
   const params = {
     grant_type: 'refresh_token',
-    refresh_token: grant.refresh_token.token
+    refresh_token: grant.refresh_token.token,
+    client_id: this.clientId,
   };
   const handler = refreshHandler(this, grant);
   const options = postOptions(this);

--- a/test/grant-manager-spec.js
+++ b/test/grant-manager-spec.js
@@ -449,6 +449,43 @@ test('GrantManager#obtainDirectly should work with https', (t) => {
     .then(t.end);
 });
 
+test('GrantManager#ensureFreshness should fetch new access token with client id ', (t) => {
+  const refreshedToken = {
+    "access_token": "some.access.token",
+    "expires_in": 30,
+    "refresh_expires_in": 1800,
+    "refresh_token": "i-Am-The-Refresh-Token",
+    "token_type": "bearer",
+    "id_token": "some-id-token",
+    "not-before-policy": 1462208947,
+    "session_state": "ess-sion-tat-se"
+  };
+  nock('http://localhost:8080')
+    .post('/auth/realms/nodejs-test/protocol/openid-connect/token', {
+      grant_type: 'refresh_token',
+      client_id: 'public-client',
+      refresh_token: 'i-Am-The-Refresh-Token'
+    })
+    .reply(204, refreshedToken);
+
+  const grant = {
+    isExpired: function(){
+      return true;
+    },
+    refresh_token: {
+      token: 'i-Am-The-Refresh-Token',
+      isExpired: () => false,
+    }
+  };
+
+  const manager = getManager('./test/fixtures/auth-utils/keycloak-public.json');
+  manager.createGrant = (t) => { return Promise.resolve(t); };
+  manager.ensureFreshness(grant)
+    .then((grant) => {
+      t.true(grant === JSON.stringify(refreshedToken));
+    }).then(t.end);
+});
+
 test('GrantManager#validateToken returns undefined for an invalid token', (t) => {
   const expiredToken = {
     isExpired: () => true

--- a/test/grant-manager-spec.js
+++ b/test/grant-manager-spec.js
@@ -451,14 +451,14 @@ test('GrantManager#obtainDirectly should work with https', (t) => {
 
 test('GrantManager#ensureFreshness should fetch new access token with client id ', (t) => {
   const refreshedToken = {
-    "access_token": "some.access.token",
-    "expires_in": 30,
-    "refresh_expires_in": 1800,
-    "refresh_token": "i-Am-The-Refresh-Token",
-    "token_type": "bearer",
-    "id_token": "some-id-token",
-    "not-before-policy": 1462208947,
-    "session_state": "ess-sion-tat-se"
+    'access_token': 'some.access.token',
+    'expires_in': 30,
+    'refresh_expires_in': 1800,
+    'refresh_token': 'i-Am-The-Refresh-Token',
+    'token_type': 'bearer',
+    'id_token': 'some-id-token',
+    'not-before-policy': 1462208947,
+    'session_state': 'ess-sion-tat-se'
   };
   nock('http://localhost:8080')
     .post('/auth/realms/nodejs-test/protocol/openid-connect/token', {
@@ -469,12 +469,12 @@ test('GrantManager#ensureFreshness should fetch new access token with client id 
     .reply(204, refreshedToken);
 
   const grant = {
-    isExpired: function(){
+    isExpired: function () {
       return true;
     },
     refresh_token: {
       token: 'i-Am-The-Refresh-Token',
-      isExpired: () => false,
+      isExpired: () => false
     }
   };
 


### PR DESCRIPTION
When token is renewed on POST request to '/auth/realms/master/protocol/openid-connect/token', RHEL-SSO 7.1 throws back error as below.
{"error":"unauthorized_client","error_description":"UNKNOWN_CLIENT: Client was not identified by any client authenticator"}

This is fixed by adding client_id to the http request getting token
renewed.