### PR TITLE
KEYCLOAK-5823 Fix service calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 node_modules/
 keycloak-*
 !keycloak-*.json
+!keycloak-connect-rest-mixed-client-spec.js
 !keycloak-connect-test.js
 !keycloak-object-test.js
 !keycloak-fixture.json

--- a/index.js
+++ b/index.js
@@ -254,7 +254,6 @@ Keycloak.prototype.getGrant = function (request, response) {
   if (grantData && !grantData.error) {
     var self = this;
     return this.grantManager.createGrant(JSON.stringify(grantData))
-    .then(grant => { return this.grantManager.ensureFreshness(grant); })
     .then(grant => {
       self.storeGrant(grant, request, response);
       return grant;
@@ -266,8 +265,9 @@ Keycloak.prototype.getGrant = function (request, response) {
 };
 
 Keycloak.prototype.storeGrant = function (grant, request, response) {
-  if (this.stores.length < 2) {
-    // cannot store, bearer-only, this is weird
+  if (this.stores.length < 2 || BearerStore.get(request)) {
+    // cannot store bearer-only, and should not store if grant is from the
+    // authorization header
     return;
   }
   if (!grant) {

--- a/test/fixtures/templates/confidential-template.json
+++ b/test/fixtures/templates/confidential-template.json
@@ -2,6 +2,7 @@
     "clientId": "{{name}}",
     "rootUrl": "http://localhost:{{port}}",
     "enabled": true,
+    "directAccessGrantsEnabled": true,
     "redirectUris": [
         "http://localhost:{{port}}/*"
     ],

--- a/test/keycloak-connect-rest-mixed-client-spec.js
+++ b/test/keycloak-connect-rest-mixed-client-spec.js
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017 Red Hat Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+'use strict';
+
+const admin = require('./utils/realm');
+const NodeApp = require('./fixtures/node-console/index').NodeApp;
+
+const test = require('blue-tape');
+const roi = require('roi');
+const getToken = require('./utils/token');
+
+const realmName = 'mixed-mode-realm';
+const realmManager = admin.createRealm(realmName);
+const app = new NodeApp();
+
+const auth = {
+  username: 'test-admin',
+  password: 'password'
+};
+
+const getSessionCookie = response => response.headers['set-cookie'][0].split(';')[0];
+
+test('setup', t => {
+  return realmManager.then(() => {
+    return admin.createClient(app.confidential(), realmName)
+    .then((installation) => {
+      return app.build(installation);
+    });
+  });
+});
+
+test('Should test protected route.', t => {
+  t.plan(1);
+  const opt = {
+    'endpoint': app.address + '/service/admin'
+  };
+  return t.shouldFail(roi.get(opt), 'Access denied', 'Response should be access denied for no credentials');
+});
+
+test('Should test protected route with admin credentials.', t => {
+  t.plan(1);
+  return getToken({ realmName }).then((token) => {
+    var opt = {
+      endpoint: app.address + '/service/admin',
+      headers: {
+        Authorization: 'Bearer ' + token
+      }
+    };
+    return roi.get(opt)
+    .then(x => {
+      t.equal(JSON.parse(x.body).message, 'admin');
+    });
+  });
+});
+
+test('Should test protected route with invalid access token.', t => {
+  t.plan(1);
+  return getToken({ realmName }).then((token) => {
+    var opt = {
+      endpoint: app.address + '/service/admin',
+      headers: {
+        Authorization: 'Bearer ' + token.replace(/(.+?\..+?\.).*/, '$1.Invalid')
+      }
+    };
+    return t.shouldFail(roi.get(opt), 'Access denied', 'Response should be access denied for invalid access token');
+  });
+});
+
+test('Should handle direct access grants.', t => {
+  const endpoint = app.address + '/service/grant';
+  t.plan(3);
+
+  return roi.post({ endpoint }, auth)
+  .then(res => JSON.parse(res.body))
+  .then(body => {
+    t.ok(body.id_token, 'Response should contain an id_token');
+    t.ok(body.access_token, 'Response should contain an access_token');
+    t.ok(body.refresh_token, 'Response should contain an refresh_token');
+  });
+});
+
+test('Should store the grant.', t => {
+  const endpoint = app.address + '/service/grant';
+  t.plan(3);
+  return roi.post({ endpoint }, auth)
+  .then(res => getSessionCookie(res))
+  .then(cookie => {
+    return roi.get({ endpoint, headers: { cookie } })
+    .then(res => JSON.parse(res.body))
+    .then(body => {
+      t.ok(body.id_token, 'Response should contain an id_token');
+      t.ok(body.access_token, 'Response should contain an access_token');
+      t.ok(body.refresh_token, 'Response should contain an refresh_token');
+    });
+  });
+});
+
+test('Should not store grant on bearer request', t => {
+  t.plan(4);
+  const endpoint = app.address + '/service/grant';
+  let sessionCookie;
+
+  return roi.post({ endpoint }, auth)
+  .then(res => {
+    const data = {
+      cookie: getSessionCookie(res),
+      grant: JSON.parse(res.body)
+    };
+    sessionCookie = data.cookie;
+    return data;
+  })
+  .then(data => {
+    const opt = {
+      endpoint: app.address + '/service/secured',
+      headers: {
+        Authorization: 'Bearer ' + data.grant.access_token.token,
+        Cookie: data.cookie
+      }
+    };
+
+    return roi.get(opt)
+    .then(res => JSON.parse(res.body))
+    .then(body => {
+      t.equal(body.message, 'secured');
+
+      const opt = {
+        endpoint,
+        headers: {
+          Cookie: sessionCookie
+        }
+      };
+
+      return roi.get(opt)
+      .then(res => JSON.parse(res.body))
+      .then(body => {
+        t.ok(body.id_token, 'Response should contain an id_token');
+        t.ok(body.access_token, 'Response should contain an access_token');
+        t.ok(body.refresh_token, 'Response should contain an refresh_token');
+      });
+    });
+  });
+});
+
+test('teardown', t => {
+  return realmManager.then((realm) => {
+    app.destroy();
+    admin.destroy(realmName);
+  });
+});

--- a/test/utils/token.js
+++ b/test/utils/token.js
@@ -3,7 +3,7 @@
 const requester = require('keycloak-request-token');
 const baseUrl = 'http://127.0.0.1:8080/auth';
 
-const settings = {
+const defaultSettings = {
   username: 'test-admin',
   password: 'password',
   grant_type: 'password',
@@ -11,4 +11,7 @@ const settings = {
   realmName: 'service-node-realm'
 };
 
-module.exports = () => requester(baseUrl, settings);
+module.exports = (options) => {
+  const settings = Object.assign({}, defaultSettings, options);
+  return requester(baseUrl, settings);
+};


### PR DESCRIPTION
Fix regression causing service calls to clients not configured as bearer-only to fail.

This change makes Keycloak Connect behave similarly to Keycloak's Java adapters when a token is requested and but a refresh token is not present.