### PR TITLE
Revert "[KEYCLOAK-6171] Node.js adapter doesn't remove "session_state" from URL after login

### DIFF
--- a/index.js
+++ b/index.js
@@ -309,6 +309,7 @@ Keycloak.prototype.loginUrl = function (uuid, redirectUrl) {
   return this.config.realmUrl +
   '/protocol/openid-connect/auth' +
   '?client_id=' + encodeURIComponent(this.config.clientId) +
+  '&state=' + encodeURIComponent(uuid) +
   '&redirect_uri=' + encodeURIComponent(redirectUrl) +
   '&scope=' + encodeURIComponent(this.config.scope ? 'openid ' + this.config.scope : 'openid') +
   '&response_type=code';


### PR DESCRIPTION
This reverts commit 01cf8a63805d1bbef04e3b2524d5b7f2c5adf7be.