### PR TITLE
Display promise error massage

### DIFF
--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -362,8 +362,8 @@ GrantManager.prototype.validateToken = function validateToken (token) {
           } else {
             resolve(token);
           }
-        }, () => {
-          reject(new Error('failed to load public key to verify token'));
+        }).catch((err) => {
+          reject(new Error('failed to load public key to verify token. Reason: ' + err.message));
         });
       }
     }

--- a/test/grant-manager-spec.js
+++ b/test/grant-manager-spec.js
@@ -433,7 +433,7 @@ test('GrantManager should fail to load public key when kid is empty', (t) => {
       return manager.validateToken(grant.access_token);
     })
     .catch(e => {
-      t.equal(e.message, 'failed to load public key to verify token');
+      t.equal(e.message, 'failed to load public key to verify token. Reason: Expected "jwk" to be an Object');
     })
     .then(t.end);
 });


### PR DESCRIPTION
I was hard to debug in `GrantManager.prototype.validateToken`. 
(The reason was self signed certificate error)

So, I want to display promise error reason. 🙏 