### PR TITLE
[KEYCLOAK-6093] grant_type refresh_token throws 'invalid_client_credentials', when client_id is missing

### DIFF
--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -155,7 +155,8 @@ GrantManager.prototype.ensureFreshness = function ensureFreshness (grant, callba
 
   const params = {
     grant_type: 'refresh_token',
-    refresh_token: grant.refresh_token.token
+    refresh_token: grant.refresh_token.token,
+    client_id: this.clientId
   };
   const handler = refreshHandler(this, grant);
   const options = postOptions(this);


### PR DESCRIPTION
grant_type refresh_token throws 'invalid_client_credentials', when
client_id is not a part of openid-connect/token request
When token is renewed on POST request to
'/auth/realms/master/protocol/openid-connect/token', RHEL-SSO 7.1 throws
back error as below.
{"error":"unauthorized_client","error_description":"UNKNOWN_CLIENT:
Client was not identified by any client authenticator"}

This is fixed by adding client_id to the http request getting token
renewed.