### PR TITLE
KEYCLOAK-7193 Correct base path in product build pom

### DIFF
--- a/product/pom.xml
+++ b/product/pom.xml
@@ -59,7 +59,7 @@
                             <outputDirectory>${project.build.outputDirectory}</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.basedir}</directory>
+                                    <directory>${project.basedir}/../</directory>
                                     <includes>
                                         <include>example/**</include>
                                         <include>index.js</include>
@@ -90,7 +90,7 @@
                             <goal>set-properties</goal>
                         </goals>
                         <configuration>
-                            <file>package.json</file>
+                            <file>${project.basedir}/../package.json</file>
                             <properties>
                                 <version.js.phantomjs>$.devDependencies.phantomjs-prebuilt</version.js.phantomjs>
                                 <version.js.nsp>$.devDependencies.nsp</version.js.nsp>
@@ -216,7 +216,7 @@
                         </goals>
                         <configuration>
                             <descriptors>
-                                <descriptor>dist.xml</descriptor>
+                                <descriptor>${project.basedir}/dist.xml</descriptor>
                             </descriptors>
                             <appendAssemblyId>false</appendAssemblyId>
                             <tarLongFileMode>posix</tarLongFileMode>


### PR DESCRIPTION
The PR for KEYCLOAK-6909 (#121) was modified to put the new stuff in a
subdirectory. I omitted to check that the pom would actually build from this
new location, and it doesn't.

In a couple places I've added a `../` so that the paths point to the repo root
again, so the build actually works now. Sorry for not checking this before.