### PR TITLE
Add configurable host and port for Docker Compose

### DIFF
--- a/middleware/auth-utils/config.js
+++ b/middleware/auth-utils/config.js
@@ -161,6 +161,16 @@ Config.prototype.configure = function configure (config) {
     }
     this.publicKey += '-----END PUBLIC KEY-----\n';
   }
+
+  /**
+   * Configurable host for keycloak auth server.
+   */
+  this.authServerHost = config['auth-server-host'] || config.authServerHost;
+
+  /**
+   * Configurable port number for keycloak auth server.
+   */
+  this.authServerPort = config['auth-server-port'] || config.authServerPort;
 };
 
 module.exports = Config;

--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -39,6 +39,8 @@ function GrantManager (config) {
   this.public = config.public;
   this.bearerOnly = config.bearerOnly;
   this.notBefore = 0;
+  this.authServerHost = config.authServerHost;
+  this.authServerPort = config.authServerPort;
   this.rotation = new Rotation(config);
 }
 
@@ -99,6 +101,14 @@ GrantManager.prototype.obtainFromCode = function obtainFromCode (request, code, 
   };
   const handler = createHandler(this);
   const options = postOptions(this);
+
+  if (this.authServerHost) {
+    options.hostname = this.authServerHost;
+  }
+
+  if (this.authServerPort) {
+    options.port = this.authServerPort;
+  }
 
   return nodeify(fetch(this, handler, options, params), callback);
 };

--- a/test/fixtures/auth-utils/keycloak-docker.json
+++ b/test/fixtures/auth-utils/keycloak-docker.json
@@ -1,0 +1,10 @@
+{
+  "server-url" : "https://localhost:8080/auth",
+  "realm" : "nodejs-test",
+  "min-time-between-jwks-requests" : 0,
+  "ssl-required" : "external",
+  "resource" : "public-client",
+  "public-client" : true,
+  "auth-server-host" : "someFakeHost",
+  "auth-server-port" : 9090
+}

--- a/test/grant-manager-spec.js
+++ b/test/grant-manager-spec.js
@@ -536,3 +536,16 @@ test('GrantManager#validateToken returns undefined for an invalid token', (t) =>
   }
   t.end();
 });
+
+test('GrantManager#obtainFromCode should try to connect to a configurable host and port', (t) => {
+  const dockerManager = getManager('./test/fixtures/auth-utils/keycloak-docker.json');
+  const fakeRequest = {};
+  const fakeCode = 'a-fake-code';
+
+  dockerManager.obtainFromCode(fakeRequest, fakeCode)
+    .catch((err) => {
+      t.true(err instanceof Error, err.message);
+      t.equal(err.message, 'getaddrinfo ENOTFOUND somefakehost somefakehost:9090');
+    })
+    .then(t.end);
+});


### PR DESCRIPTION
Using keycloak-connect within a Docker service is currently tricky. The
module uses the same host and port for both the auth server as well as
the app server. However, with docker-compose it is extremely easy to
have the two running in separate containers, causing issues with what
exactly does localhost refer to, and also not properly mapping back to
the appropriate port number in the other container. This commit simply
adds the ability to specify these such that when a grant is obtained
from code, the host and port to connect to inside the http request
can be customized.