### PR TITLE
KEYCLOAK-7343 Correct the paths defined for PME's jsonUpdate

### DIFF
--- a/product/prod-arguments.json
+++ b/product/prod-arguments.json
@@ -14,7 +14,7 @@
         "dependencyManagement": "org.jboss.eap:jboss-eap-parent:$EAP_VERSION",
         "dependencyRelocations.org.wildfly:@org.jboss.eap:": "$EAP_VERSION",
         "dependencyExclusion.org.jboss:jboss-parent@*": "19.0.0.redhat-2",
-        "jsonUpdate": "package.json:$.devDependencies.keycloak-admin-client:^0.12.0,package.json:$.scripts.prepublish:"
+        "jsonUpdate": "../package.json:$.devDependencies.keycloak-admin-client:^0.12.0,../package.json:$.scripts.prepublish:"
     }
   }
 }


### PR DESCRIPTION
Further to KEYCLOAK-7193 and KEYCLOAK-6909.

prod-arguments.json defines a couple PME jsonUpdate paths. It turns out these
paths are resolved relative to the pom location, not the current working
directory, so ../ must be added to compensate for the maven stuff being located
in a subdirectory.