### PR TITLE
[KEYCLOAK-7532] Fix incomplet token validation

### DIFF
--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -282,10 +282,10 @@ GrantManager.prototype.createGrant = function createGrant (rawData) {
  */
 GrantManager.prototype.validateGrant = function validateGrant (grant) {
   var self = this;
-  const validateGrantToken = (grant, tokenName) => {
+  const validateGrantToken = (grant, tokenName, expectedType) => {
     return new Promise((resolve, reject) => {
     // check the access token
-      this.validateToken(grant[tokenName]).then(token => {
+      this.validateToken(grant[tokenName], expectedType).then(token => {
         grant[tokenName] = token;
         resolve();
       }).catch((err) => {
@@ -295,13 +295,13 @@ GrantManager.prototype.validateGrant = function validateGrant (grant) {
   };
   return new Promise((resolve, reject) => {
     var promises = [];
-    promises.push(validateGrantToken(grant, 'access_token'));
+    promises.push(validateGrantToken(grant, 'access_token', 'Bearer'));
     if (!self.bearerOnly) {
       if (grant.refresh_token) {
-        promises.push(validateGrantToken(grant, 'refresh_token'));
+        promises.push(validateGrantToken(grant, 'refresh_token', 'Refresh'));
       }
       if (grant.id_token) {
-        promises.push(validateGrantToken(grant, 'id_token'));
+        promises.push(validateGrantToken(grant, 'id_token', 'ID'));
       }
     }
     Promise.all(promises).then(() => {
@@ -328,7 +328,7 @@ GrantManager.prototype.validateGrant = function validateGrant (grant) {
  *
  * @return {Promise} That resolve a token
  */
-GrantManager.prototype.validateToken = function validateToken (token) {
+GrantManager.prototype.validateToken = function validateToken (token, expectedType) {
   return new Promise((resolve, reject) => {
     if (!token) {
       reject(new Error('invalid token (missing)'));
@@ -336,6 +336,8 @@ GrantManager.prototype.validateToken = function validateToken (token) {
       reject(new Error('invalid token (expired)'));
     } else if (!token.signed) {
       reject(new Error('invalid token (not signed)'));
+    } else if (token.content.typ !== expectedType) {
+      reject(new Error('invalid token (wrong type)'));
     } else if (token.content.iat < this.notBefore) {
       reject(new Error('invalid token (future dated)'));
     } else if (token.content.iss !== this.realmUrl) {

--- a/test/grant-manager-spec.js
+++ b/test/grant-manager-spec.js
@@ -58,7 +58,7 @@ test('GrantManager should return empty with public key configured but invalid si
   manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {
       grant.access_token.signature = 'da39a3ee5e6b4b0d3255bfef95601890afd80709';
-      return manager.validateToken(grant.access_token);
+      return manager.validateToken(grant.access_token, 'Bearer');
     })
     .catch((e) => {
       t.equal(e.message, 'invalid token (signature)');
@@ -418,10 +418,21 @@ test('GrantManager should validate unsigned token', (t) => {
   manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {
       grant.access_token.signed = false;
-      return manager.validateToken(grant.access_token);
+      return manager.validateToken(grant.access_token, 'Bearer');
     })
     .catch(e => {
       t.equal(e.message, 'invalid token (not signed)');
+    })
+    .then(t.end);
+});
+
+test('GrantManager should not validate token with wrong type', (t) => {
+  manager.obtainDirectly('test-user', 'tiger')
+    .then((grant) => {
+      return manager.validateToken(grant.access_token, 'Refresh');
+    })
+    .catch(e => {
+      t.equal(e.message, 'invalid token (wrong type)');
     })
     .then(t.end);
 });
@@ -430,7 +441,7 @@ test('GrantManager should fail to load public key when kid is empty', (t) => {
   manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {
       grant.access_token.header.kid = {};
-      return manager.validateToken(grant.access_token);
+      return manager.validateToken(grant.access_token, 'Bearer');
     })
     .catch(e => {
       t.equal(e.message, 'failed to load public key to verify token. Reason: Expected "jwk" to be an Object');
@@ -442,7 +453,7 @@ test('GrantManager should fail with invalid signature', (t) => {
   manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {
       grant.access_token.signature = 'da39a3ee5e6b4b0d3255bfef95601890afd80709';
-      return manager.validateToken(grant.access_token);
+      return manager.validateToken(grant.access_token, 'Bearer');
     })
     .catch(e => {
       t.equal(e.message, 'invalid token (public key signature)');
@@ -529,7 +540,7 @@ test('GrantManager#validateToken returns undefined for an invalid token', (t) =>
 
   /* jshint loopfunc:true */
   for (const token of tokens) {
-    manager.validateToken(token)
+    manager.validateToken(token, 'Bearer')
     .catch((err) => {
       t.true(err instanceof Error, err.message);
     });


### PR DESCRIPTION
While validateGrant, a refresh_token may be validated
as access_token (easy to do with bearer-only api)

This fix add a type checking on attribute 'typ' on the token.
Three kinds of token can be validated:
- Bearer: access_token
- Refresh: refresh_token
- ID: id_token