### PR TITLE
KEYCLOAK-7684 Remove scripts.prepublish delete command from PME jsonUpdate

### DIFF
--- a/product/prod-arguments.json
+++ b/product/prod-arguments.json
@@ -14,7 +14,7 @@
         "dependencyManagement": "org.jboss.eap:jboss-eap-parent:$EAP_VERSION",
         "dependencyRelocations.org.wildfly:@org.jboss.eap:": "$EAP_VERSION",
         "dependencyExclusion.org.jboss:jboss-parent@*": "19.0.0.redhat-2",
-        "jsonUpdate": "../package.json:$.devDependencies.keycloak-admin-client:^0.12.0,../package.json:$.scripts.prepublish:"
+        "jsonUpdate": "../package.json:$.devDependencies.keycloak-admin-client:^0.12.0"
     }
   }
 }


### PR DESCRIPTION
Commit a6c86176 removed nsp, so deleting it for the product is no longer
required. The associated command has to be removed however, otherwise PME
errors out in PNC.

Linked with #135