### PR TITLE
KEYCLOAK-7711 Remove nsp from product build pom

### DIFF
--- a/product/pom.xml
+++ b/product/pom.xml
@@ -93,7 +93,6 @@
                             <file>${project.basedir}/../package.json</file>
                             <properties>
                                 <version.js.phantomjs>$.devDependencies.phantomjs-prebuilt</version.js.phantomjs>
-                                <version.js.nsp>$.devDependencies.nsp</version.js.nsp>
                             </properties>
                         </configuration>
                     </execution>
@@ -159,16 +158,6 @@
                         <configuration>
                             <nodeVersion>${version.js.node}</nodeVersion>
                             <npmVersion>${version.js.npm}</npmVersion>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>npm-install-nsp</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <phase>compile</phase>
-                        <configuration>
-                            <arguments>install nsp@${version.js.nsp} --no-shrinkwrap</arguments>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Missed this in the fix for KEYCLOAK-7684, same thing but the pom. I've actually
tried a local build this time, and it works, so this should be the last fix.