### PR TITLE
[KEYCLOAK-8075] Pass `next` to `accessDenied` method to allow error handling

### DIFF
--- a/middleware/post-auth.js
+++ b/middleware/post-auth.js
@@ -49,7 +49,7 @@ module.exports = function (keycloak) {
         }
         response.redirect(cleanUrl);
       }).catch((err) => {
-        keycloak.accessDenied(request, response);
+        keycloak.accessDenied(request, response, next);
         console.error('Could not obtain grant code: ' + err);
       });
   };


### PR DESCRIPTION
The `next` callback was not being passed in this instance of `keycloak.accessDenied` (as opposed to the similar call on L27). This means that implementations cannot easily handle the error using standard express error handling mechanisms.