### PR TITLE
Propagate the error on getGrant

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ Keycloak.prototype.getGrant = function (request, response) {
     .catch((error) => { return Promise.reject(error); });
   }
 
-  return Promise.reject();
+  return Promise.reject(grantData ? grantData.error : new Error('No token avaiable'));
 };
 
 Keycloak.prototype.storeGrant = function (grant, request, response) {

--- a/index.js
+++ b/index.js
@@ -311,7 +311,7 @@ Keycloak.prototype.getGrant = function (request, response) {
       self.storeGrant(grant, request, response);
       return grant;
     })
-    .catch(() => { return Promise.reject(); });
+    .catch((error) => { return Promise.reject(error); });
   }
 
   return Promise.reject();


### PR DESCRIPTION
Once the createGrant fail I need the error propagated so I can deal with it in my client.