### PR TITLE
[KEYCLOAK-8663] RTE in enforce when no Auth header

### DIFF
--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -133,12 +133,12 @@ GrantManager.prototype.checkPermissions = function obtainPermissions (authzReque
     let header = request.headers.authorization;
     let bearerToken;
 
-    if (header && header.indexOf('bearer ') === 0 || header.indexOf('Bearer ') === 0) {
+    if (header && (header.indexOf('bearer ') === 0 || header.indexOf('Bearer ') === 0)) {
       bearerToken = header.substring(7);
     }
 
     if (!bearerToken) {
-      return;
+      return Promise.reject('No bearer in header');
     }
 
     params.subject_token = bearerToken;

--- a/test/keycloak-connect-rest-enforcer-spec.js
+++ b/test/keycloak-connect-rest-enforcer-spec.js
@@ -55,6 +55,20 @@ test('Should test access to protected resource and scope view.', t => {
   });
 });
 
+test('Should test access to protected resource and scope view without authorization header.', t => {
+  t.plan(2);
+  return getToken({ realmName }).then((token) => {
+    var opt = {
+      endpoint: app.address + '/protected/enforcer/resource'
+    };
+    return roi.get(opt)
+      .catch(x => {
+        t.equal(x.length, 1);
+        t.equal(x[0], 'Access denied');
+      });
+  });
+});
+
 test('Should test access to protected resource and scope update - and returned permissions.', t => {
   t.plan(4);
   return getToken({ realmName }).then((token) => {


### PR DESCRIPTION
Fixed a bug related to calling enforce without Authorization header.
The enforce function now also correctly returns a promise to the
calling function in the case of no Authorization header.