### PR TITLE
Redirect to register page in case of register

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,8 +183,8 @@ Keycloak.prototype.middleware = function (options) {
  *
  * @param {String} spec The protection spec (optional)
  */
-Keycloak.prototype.protect = function (spec) {
-  return Protect(this, spec);
+Keycloak.prototype.protect = function (spec, route) {
+  return Protect(this, spec, route);
 };
 
 /**
@@ -385,6 +385,17 @@ Keycloak.prototype.loginUrl = function (uuid, redirectUrl) {
   }
   return url;
 };
+
+Keycloak.prototype.registerUrl = function (redirectUrl) {
+  var url = this.config.realmUrl +
+  '/protocol/openid-connect/registrations' +
+  '?client_id=' + encodeURIComponent(this.config.clientId) +
+  '&redirect_uri=' + encodeURIComponent(redirectUrl) +
+  '&scope=' + encodeURIComponent(this.config.scope ? 'openid ' + this.config.scope : 'openid') +
+  '&response_type=code';
+
+  return url;
+}
 
 Keycloak.prototype.logoutUrl = function (redirectUrl) {
   return this.config.realmUrl +

--- a/index.js
+++ b/index.js
@@ -183,8 +183,8 @@ Keycloak.prototype.middleware = function (options) {
  *
  * @param {String} spec The protection spec (optional)
  */
-Keycloak.prototype.protect = function (spec, route) {
-  return Protect(this, spec, route);
+Keycloak.prototype.protect = function (spec) {
+  return Protect(this, spec);
 };
 
 /**

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -17,7 +17,7 @@
 
 const UUID = require('./../uuid');
 
-function forceLogin (keycloak, request, response) {
+function forceLogin (keycloak, request, response, routeName) {
   let host = request.hostname;
   let headerHost = request.headers.host.split(':');
   let port = headerHost[1] || '';
@@ -31,7 +31,7 @@ function forceLogin (keycloak, request, response) {
   }
 
   let uuid = UUID();
-  let loginURL = keycloak.loginUrl(uuid, redirectUrl);
+  let loginURL = (routeName === "register") ? keycloak.registerUrl(redirectUrl) : keycloak.loginUrl(uuid, redirectUrl);
   response.redirect(loginURL);
 }
 
@@ -39,7 +39,7 @@ function simpleGuard (role, token) {
   return token.hasRole(role);
 }
 
-module.exports = function (keycloak, spec) {
+module.exports = function (keycloak, spec, routeName) {
   let guard;
 
   if (typeof spec === 'function') {
@@ -58,7 +58,7 @@ module.exports = function (keycloak, spec) {
     }
 
     if (keycloak.redirectToLogin(request)) {
-      forceLogin(keycloak, request, response);
+      forceLogin(keycloak, request, response, routeName);
     } else {
       return keycloak.accessDenied(request, response, next);
     }


### PR DESCRIPTION
We have developed a new method to build a register route. Protect function takes a second parameter i.e. register and decides to build a register url same as login url does.