### PR TITLE
 [KEYCLOAK-10043] Support check-sso option in the Node.js adapter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Bug fixes and features should come with tests. Add your tests in the
 To write the tests you will need keycloak server running, so run this script:
 
 ```shell
-$ ./scripts/build/start-server.sh
+$ ./scripts/start-server.sh
 ```
 This will download, configure and start keycloak server.
 
@@ -106,7 +106,7 @@ $ make
 Then to stop the server by running this script:
 
 ```shell
-$ ./scripts/build/stop-server.sh
+$ ./scripts/stop-server.sh
 ```
 
 Make sure the jshint and semistandard are happy and that all tests pass. Please, do not submit

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ var PostAuth = require('./middleware/post-auth');
 var GrantAttacher = require('./middleware/grant-attacher');
 var Protect = require('./middleware/protect');
 var Enforcer = require('./middleware/enforcer');
+var CheckSso = require('./middleware/check-sso');
 
 /**
  * Instantiate a Keycloak.
@@ -237,6 +238,18 @@ Keycloak.prototype.protect = function (spec) {
  */
 Keycloak.prototype.enforcer = function (permissions, config) {
   return new Enforcer(this, config).enforce(permissions);
+};
+
+/**
+ * Apply check SSO middleware to an application or specific URL.
+ *
+ * Check SSO will only authenticate the client if the user is already logged-in,
+ * if the user is not logged-in the browser will be redirected back
+ * to the originally-requested URL and remain unauthenticated.
+ *
+ */
+Keycloak.prototype.checkSso = function () {
+  return CheckSso(this);
 };
 
 /**

--- a/middleware/check-sso.js
+++ b/middleware/check-sso.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Red Hat Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+'use strict';
+
+const UUID = require('./../uuid');
+const URL = require('url');
+
+function forceCheckSSO (keycloak, request, response) {
+  const host = request.hostname;
+  const headerHost = request.headers.host.split(':');
+  const port = headerHost[1] || '';
+  const protocol = request.protocol;
+  let hasQuery = ~(request.originalUrl || request.url).indexOf('?');
+
+  const redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + (request.originalUrl || request.url) + (hasQuery ? '&' : '?') + 'auth_callback=1';
+
+  if (request.session) {
+    request.session.auth_redirect_uri = redirectUrl;
+  }
+
+  const uuid = UUID();
+  const loginURL = keycloak.loginUrl(uuid, redirectUrl);
+  const checkSsoUrl = loginURL + '&response_mode=query&prompt=none';
+
+  response.redirect(checkSsoUrl);
+}
+
+module.exports = function (keycloak) {
+  return function checkSso (request, response, next) {
+    if (request.kauth && request.kauth.grant) {
+      return next();
+    }
+
+    //  Check SSO process is completed and user is not logged in
+    if (request.session.auth_is_check_sso_complete) {
+      request.session.auth_is_check_sso_complete = false;
+      return next();
+    }
+
+    //  Keycloak server has just answered that user is not logged in
+    if (request.query.error === 'login_required') {
+      let urlParts = {
+        pathname: request.path,
+        query: request.query
+      };
+
+      delete urlParts.query.error;
+      delete urlParts.query.auth_callback;
+      delete urlParts.query.state;
+
+      let cleanUrl = URL.format(urlParts);
+
+      //  Check SSO process is completed
+      request.session.auth_is_check_sso_complete = true;
+
+      //  Redirect back to the original URL
+      return response.redirect(cleanUrl);
+    }
+
+    if (keycloak.redirectToLogin(request)) {
+      forceCheckSSO(keycloak, request, response);
+    } else {
+      return keycloak.accessDenied(request, response, next);
+    }
+  };
+};

--- a/middleware/post-auth.js
+++ b/middleware/post-auth.js
@@ -23,6 +23,11 @@ module.exports = function (keycloak) {
       return next();
     }
 
+    //  During the check SSO process the Keycloak server answered the user is not logged in
+    if (request.query.error === 'login_required') {
+      return next();
+    }
+
     if (request.query.error) {
       return keycloak.accessDenied(request, response, next);
     }

--- a/scripts/stop-server.sh
+++ b/scripts/stop-server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Stop the image
+docker stop keycloak

--- a/test/fixtures/node-console/index.js
+++ b/test/fixtures/node-console/index.js
@@ -116,6 +116,11 @@ function NodeApp () {
       output(res, JSON.stringify(JSON.parse(req.session['keycloak-token']), null, 4), 'Auth Success');
     });
 
+    app.get('/check-sso', keycloak.checkSso(), function (req, res) {
+      var authenticated = 'Check SSO Success (' + (req.session['keycloak-token'] ? 'Authenticated' : 'Not Authenticated') + ')';
+      output(res, authenticated);
+    });
+
     app.get('/restricted', keycloak.protect('realm:admin'), function (req, res) {
       var user = req.kauth.grant.access_token.content.preferred_username;
       output(res, user, 'Restricted access');

--- a/test/keycloak-connect-web-spec.js
+++ b/test/keycloak-connect-web-spec.js
@@ -156,6 +156,30 @@ test('Confidential client should be forbidden for invalid public key', t => {
   });
 });
 
+test('Should test check SSO after logging in and logging out', t => {
+  t.plan(3);
+
+  // make sure user is logged out
+  return page.logout(app.port).then(() => {
+    page.get(app.port, '/check-sso');
+    return page.output().getText().then(text => {
+      t.equal(text, 'Check SSO Success (Not Authenticated)', 'User should not be authenticated');
+      page.logInButton().click();
+      page.login('alice', 'password');
+      page.get(app.port, '/check-sso');
+      return page.output().getText().then(text => {
+        t.equal(text, 'Check SSO Success (Authenticated)', 'User should be authenticated');
+        return page.logout(app.port);
+      }).then(() => {
+        page.get(app.port, '/check-sso');
+        return page.output().getText().then(text => {
+          t.equal(text, 'Check SSO Success (Not Authenticated)', 'User should not be authenticated');
+        });
+      });
+    });
+  });
+});
+
 test('teardown', t => {
   return realmManager.then((realm) => {
     app.destroy();


### PR DESCRIPTION
A check SSO will only authenticate the client if the user is already
logged-in, if the user is not logged-in the browser will be redirected
back to the originally-requested URL and remain unauthenticated.

Fix CONTRIBUTING file:
- Fix wrong start server script path;
- Add a missing stop server script.