### PR TITLE
XHR 302 Redirect problem

### DIFF
--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -32,7 +32,12 @@ function forceLogin (keycloak, request, response) {
 
   let uuid = UUID();
   let loginURL = keycloak.loginUrl(uuid, redirectUrl);
-  response.redirect(loginURL);
+  if (request.xhr) {
+    response.status(401).send();
+  } else {
+    response.redirect(loginURL);
+  }
+  
 }
 
 function simpleGuard (role, token) {


### PR DESCRIPTION
Whenever you perform a XHR request with an expired session
keycloak-connect is calling the forceLogin function that responds
with a redirect to the keycloak-page.

401 Unauthorized response on expired session XHR request


