### PR TITLE
[KEYCLOAK-10442] Solve undefined resource_access on token content

### DIFF
--- a/middleware/auth-utils/token.js
+++ b/middleware/auth-utils/token.js
@@ -105,6 +105,10 @@ Token.prototype.hasRole = function hasRole (name) {
  * @return {boolean} `true` if this token has the specified role, otherwise `false`.
  */
 Token.prototype.hasApplicationRole = function hasApplicationRole (appName, roleName) {
+  if(!this.content.resource_access) {
+    return false;
+  }
+
   var appRoles = this.content.resource_access[appName];
 
   if (!appRoles) {


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-10442

When a token does not contains resource_access the hasApplicationRole method crashes

# Step to reproduce
1. Create a client with limited scope to only its own roles and realm roles
2. Use this client in an ExpressJS application
3. Protect a route by requesting an Application Role (e.g. "thisroledoesnotexist")
4. You will get an unedfined error on `Token.hasApplicationRole (./node_modules/keycloak-connect/middleware/auth-utils/token.js:108:46)`