### PR TITLE
KEYCLOAK-5954 - Read port from x-forwarded-port if present

### DIFF
--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -19,8 +19,13 @@ const UUID = require('./../uuid');
 
 function forceLogin (keycloak, request, response) {
   let host = request.hostname;
-  let headerHost = request.headers.host.split(':');
-  let port = headerHost[1] || '';
+  let port;
+  if ('x-forwarded-port' in request.headers) {
+    port = request.headers['x-forwarded-port'];
+  } else {
+    let headerHost = request.headers.host.split(':');
+    port = headerHost[1] || '';
+  }
   let protocol = request.protocol;
   let hasQuery = ~(request.originalUrl || request.url).indexOf('?');
 


### PR DESCRIPTION
As pointed out in https://github.com/keycloak/keycloak-nodejs-connect/pull/102#issuecomment-355906829 the way to make the express server specify the correct redirect URL if the server is behind a proxy is to set the `x-forwarded-proto` and `x-forwarded-host` headers. But unfortunately, the port is still obtained from the `request.headers.host`. With this change `x-forwarded-port` is honored as well, so this makes the server fully functional behind the proxy.

I'm happy to add any test or documentation if you see fit.
