### PR TITLE
KEYCLOAK-11281 Remove chromedriver from product's builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "axios": "^0.19.0",
     "blue-tape": "^1.0.0",
     "body-parser": "^1.13.3",
-    "chromedriver": "^76.0.0",
     "coveralls": "^3.0.1",
     "express": "^4.14.0",
     "express-session": "^1.14.2",
@@ -58,6 +57,9 @@
     "tap-xunit": "^2.4.1",
     "tape": "^4.6.3",
     "tape-catch": "^1.0.6"
+  },
+  "optionalDependencies": {
+    "chromedriver": "^76.0.0"
   },
   "semistandard": {
     "ignore": [

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -39,7 +39,6 @@
     <properties>
         <frontend.registry.url></frontend.registry.url>
         <frontend.download.root></frontend.download.root>
-        <chromedriver.download.root>${frontend.download.root}/node/npm</chromedriver.download.root>
         <version.js.node>v6.10.3</version.js.node>
         <version.js.npm>2.15.11</version.js.npm>
     </properties>
@@ -83,19 +82,6 @@
                 <artifactId>jsonpath-maven-plugin</artifactId>
                 <version>1.0.0</version>
                 <executions>
-                    <execution>
-                        <id>read-devdependencies</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>set-properties</goal>
-                        </goals>
-                        <configuration>
-                            <file>${project.basedir}/../package.json</file>
-                            <properties>
-                                <version.js.chromedriver>$.devDependencies.chromedriver</version.js.chromedriver>
-                            </properties>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>update-version</id>
                         <phase>process-resources</phase>
@@ -158,16 +144,6 @@
                         <configuration>
                             <nodeVersion>${version.js.node}</nodeVersion>
                             <npmVersion>${version.js.npm}</npmVersion>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>npm-install-chromedriver</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <phase>compile</phase>
-                        <configuration>
-                            <arguments>install chromedriver@${version.js.chromedriver} --chromedriver_cdnurl=${chromedriver.download.root}</arguments>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
This removes chromedriver from product's build and move chromedriver to optionalDependencies to be able to pass build in PNC but with same behavior for upstream builds. 
