### PR TITLE
[KEYCLOAK-12482] Keycloak Node.js Adapter example realm file cannot be imported

### DIFF
--- a/example/nodejs-example-realm.json
+++ b/example/nodejs-example-realm.json
@@ -84,25 +84,6 @@
                     }
                   ]
                 }
-              ],
-              "policies": [
-                {
-                  "name": "Default Policy",
-                  "description": "A policy that grants access only for users within this realm",
-                  "type": "js",
-                  "config": {
-                    "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
-                  }
-                },
-                {
-                  "name": "Default Permission",
-                  "description": "A permission that applies to the default resource type",
-                  "type": "resource",
-                  "config": {
-                    "defaultResourceType": "urn:nodejs-apiserver:resources:default",
-                    "applyPolicies": "[\"Default Policy\"]"
-                  }
-                }
               ]
             }
           }


### PR DESCRIPTION
## Verification Steps

1. Try to import the realm file inside `examples/` to the Keycloak server

## Extras

1. Run the app inside `examples/` and check if nothing was broken