### PR TITLE
fix: spec should be an optional param for protect

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -280,7 +280,7 @@ declare namespace KeycloakConnect {
      *
      * @param {String} spec The protection spec (optional)
      */
-    protect(spec: GaurdFn|string): express.RequestHandler
+    protect(spec?: GaurdFn|string): express.RequestHandler
 
     /**
      * Callback made upon successful authentication of a user.


### PR DESCRIPTION
This is a simple one. The spec parameter is optional, but the types incorrectly specify it as required.