### PR TITLE
KEYCLOAK-15441 Fix cookie-store

### DIFF
--- a/stores/cookie-store.js
+++ b/stores/cookie-store.js
@@ -32,7 +32,7 @@ CookieStore.get = (request) => {
 
 let store = (grant) => {
   return (request, response) => {
-    request.session[CookieStore.TOKEN_KEY] = grant.__raw;
+    response.cookie(CookieStore.TOKEN_KEY, grant.__raw);
   };
 };
 


### PR DESCRIPTION
Hi,

The current keycloak-connect code assumed it could access the keycloak cookie using `request.session[CookieStore.TOKEN_KEY]`, probably with a particular setup of express-session. It causes a redirect loop on login because the code can never access the cookie [related issue](https://stackoverflow.com/questions/59680056/how-to-set-up-node-js-server-with-cookie-based-keycloak-authentication-getting)

Note: The cookie store stores the tokens in the browser unencrypted. There should be a better way to do it? maybe expressjs/cookie-session? 

The following change can be tested with:
```
var express = require('express');
var path = require('path');
var Keycloak = require('keycloak-connect');
var morgan = require('morgan');
var cookieParser = require('cookie-parser');
var session = require('express-session');
var serveIndex = require('serve-index')

var app = express();
app.use(morgan('combined'))

const secret = 'mae7eiD0EeVao9th'
app.use(cookieParser());
app.use(session({ // keycloak-connect requires a session id
  secret: secret,
  resave: true,
  saveUninitialized: true,
  name: 'session'
}));

var keycloak = new Keycloak({
  cookies: true, // only use for debugging - tokens will be accessible in the browser unencrypted
});
app.use(keycloak.middleware({
  logout: '/logout',
  admin: '/'
}));

const dir = '.'
app.use('/', keycloak.protect(), express.static(dir), serveIndex(dir))

app.listen(3000);
```

Best regards