### PR TITLE
KEYCLOAK-13804 Require chromedriver only if it is not provided by env…

### DIFF
--- a/test/utils/webdriver.js
+++ b/test/utils/webdriver.js
@@ -18,7 +18,6 @@
  * An utility with the specifics for selenium
  */
 const chrome = require('selenium-webdriver/chrome');
-const chromedriver = require('chromedriver');
 const webdriver = require('selenium-webdriver');
 const args = require('minimist')(process.argv.slice(2));
 const By = webdriver.By;
@@ -54,7 +53,13 @@ function createDriver () {
 }
 
 function determineChromedriverPath () {
-  let path = args.chromedriverPath || (process.env.CHROMEDRIVER_PATH || chromedriver.path);
+  let path = args.chromedriverPath || process.env.CHROMEDRIVER_PATH;
+
+  if (!path) {
+    const chromedriver = require('chromedriver');
+    path = chromedriver.path;
+  }
+
   console.log('Using chromedriver from path: ' + path);
   return path;
 }


### PR DESCRIPTION
…ironment

This is rather a workaround than a fix, however, I would say for us should be enough. The failure was caused by failure to download/unzip chromedriver (see the second snippet in the Jira). The process of `npm install` continues because chromedriver is just optional dependency. Then when `webdriver.js` did `require('chromedriver')` it failed, because chromedriver was not correctly downloaded.

My changes execute `require('chromedriver')` only when it is really necessary, e.g. when chromedriver is not specified in the arguments/env variable. This change should be enough for us because, in CI, we use an environment variable to specifying chromedriver path.