### PR TITLE
KEYCLOAK-15813 Replace dependencyExclusion with dependencyOverride in prod-arguments

### DIFF
--- a/product/prod-arguments.json
+++ b/product/prod-arguments.json
@@ -12,7 +12,7 @@
         "dependencySource": "BOMREST",
         "dependencyManagement": "org.jboss.eap:jboss-eap-parent:$EAP_VERSION",
         "dependencyRelocations.org.wildfly:@org.jboss.eap:": "$EAP_VERSION",
-        "dependencyExclusion.org.jboss:jboss-parent@*": "19.0.0.redhat-2",
+        "dependencyOverride.org.jboss:jboss-parent@*": "19.0.0.redhat-2",
         "jsonUpdate": "../package.json:$.devDependencies.keycloak-admin-client:^0.12.0"
     }
   },


### PR DESCRIPTION
This resolves a problem with the new version of PME, which fails the build when
these old properties are present.