### PR TITLE
Fix the 500 error on the server when the headers authorization attrib…

### DIFF
--- a/stores/cookie-store.js
+++ b/stores/cookie-store.js
@@ -20,7 +20,13 @@ let CookieStore = {};
 CookieStore.TOKEN_KEY = 'keycloak-token';
 
 CookieStore.get = (request) => {
-  let value = request.cookies[CookieStore.TOKEN_KEY];
+  let value;
+  try {
+    value = request.cookies[CookieStore.TOKEN_KEY];
+  } catch (error) {
+    // ignore
+  }
+
   if (value) {
     try {
       return JSON.parse(value);

--- a/stores/session-store.js
+++ b/stores/session-store.js
@@ -21,7 +21,13 @@ function SessionStore (store) {
 
 SessionStore.TOKEN_KEY = 'keycloak-token';
 
-SessionStore.prototype.get = (request) => request.session[SessionStore.TOKEN_KEY];
+SessionStore.prototype.get = (request) => {
+  try {
+    return request.session[SessionStore.TOKEN_KEY];
+  } catch (error) {
+    // ignore
+  }
+}
 
 SessionStore.prototype.clear = function (sessionId) {
   let self = this;

--- a/stores/session-store.js
+++ b/stores/session-store.js
@@ -27,7 +27,7 @@ SessionStore.prototype.get = (request) => {
   } catch (error) {
     // ignore
   }
-}
+};
 
 SessionStore.prototype.clear = function (sessionId) {
   let self = this;


### PR DESCRIPTION
When the headers authorization property is not set on the front end, the backend nodejs application will report a 500 error.

> TypeError: Cannot read property 'keycloak-token' of undefined
    at SessionStore.get (/Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/keycloak-connect/stores/session-store.js:24:58)
    at Keycloak.getGrant (/Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/keycloak-connect/index.js:297:30)
    at grantAttacher (/Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/keycloak-connect/middleware/grant-attacher.js:20:14)
    at Layer.handle [as handle_request] (/Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/express/lib/router/index.js:317:13)
    at /Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/express/lib/router/index.js:335:12)
    at next (/Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/express/lib/router/index.js:275:10)
    at adminRequest (/Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/keycloak-connect/middleware/admin.js:103:16)
    at Layer.handle [as handle_request] (/Users/tristan_lau/Workspace/FrontendRepository/keycloak-nodejs-microservice/node_modules/express/lib/router/layer.js:95:5)