### PR TITLE
[KEYCLOAK-16726] fix redirect for restify

### DIFF
--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -33,10 +33,10 @@ function forceLogin (keycloak, request, response, next) {
   let uuid = UUID();
   let loginURL = keycloak.loginUrl(uuid, redirectUrl);
   try {
-    // expressjs not happy with next param
+    // express.js not happy with next param
     response.redirect(301, loginURL);
   } catch (ex) {
-    console.log('using Restify? expected error. Switching redirect call ..');
+    console.debug('using Restify? expected error. Switching redirect call ..', ex);
     // for restify mandatory next param
     response.redirect(301, loginURL, next);
   }

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -34,11 +34,11 @@ function forceLogin (keycloak, request, response, next) {
   let loginURL = keycloak.loginUrl(uuid, redirectUrl);
   try {
     // express.js not happy with next param
-    response.redirect(301, loginURL);
+    response.redirect(302, loginURL);
   } catch (ex) {
-    console.debug('using Restify? expected error. Switching redirect call ..', ex);
+    console.debug('Using Restify? Expected error. Switching redirect call ...', ex);
     // for restify mandatory next param
-    response.redirect(301, loginURL, next);
+    response.redirect(302, loginURL, next);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "keycloak-request-token": "^0.1.0",
     "nock": "^12.0.3",
     "nyc": "^15.0.0",
+    "restify": "^8.5.1",
     "rsa-compat": "^1.2.7",
     "selenium-webdriver": "^3.6.0",
     "semistandard": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "jwk-to-pem": "^2.0.0"
+    "jwk-to-pem": "^2.0.0",
+    "restify": "^8.5.1"
   },
   "devDependencies": {
     "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "jwk-to-pem": "^2.0.0",
-    "restify": "^8.5.1"
+    "jwk-to-pem": "^2.0.0"
   },
   "devDependencies": {
     "axios": "^0.19.0",

--- a/test/fixtures/node-console/restify.js
+++ b/test/fixtures/node-console/restify.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const Keycloak = require('../../../');
+const bodyParser = require('body-parser');
+const restify = require('restify');
+const cookieParser = require('cookie-parser');
+const enableDestroy = require('server-destroy');
+const parseClient = require('../../utils/helper').parseClient;
+
+Keycloak.prototype.redirectToLogin = function (req) {
+  var apiMatcher = /^\/service\/.*/i;
+  return !apiMatcher.test(req.baseUrl);
+};
+
+Keycloak.prototype.obtainDirectly = function (user, pass) {
+  return this.grantManager.obtainDirectly(user, pass);
+};
+
+function NodeApp () {
+  var app = restify.createServer();
+  app.use(cookieParser());
+  var server = app.listen(0);
+  enableDestroy(server);
+  this.close = function () {
+    server.close();
+  };
+  this.destroy = function () {
+    server.destroy();
+  };
+  this.port = server.address().port;
+  this.address = 'http://127.0.0.1:' + this.port;
+
+  console.log('Testing app listening at http://localhost:%s', this.port);
+
+  this.publicClient = function (app) {
+    var name = app || 'public-app';
+    return parseClient('test/fixtures/templates/public-template.json', this.port, name);
+  };
+
+  this.bearerOnly = function (app) {
+    var name = app || 'bearer-app';
+    return parseClient('test/fixtures/templates/bearerOnly-template.json', this.port, name);
+  };
+
+  this.confidential = function (app) {
+    var name = app || 'confidential-app';
+    return parseClient('test/fixtures/templates/confidential-template.json', this.port, name);
+  };
+
+  this.enforcerResourceServer = function (app) {
+    var name = app || 'resource-server-app';
+    return parseClient('test/fixtures/templates/resource-server-template.json', this.port, name);
+  };
+
+  this.build = function (kcConfig, params) {
+    params = params || {};
+    var keycloak = new Keycloak(params, kcConfig);
+
+    // A normal un-protected public URL.
+    app.get('/', function (req, res) {
+      var authenticated = 'Init Success (' + (req.session['keycloak-token'] ? 'Authenticated' : 'Not Authenticated') + ')';
+      output(res, authenticated);
+    });
+
+    // Install the Keycloak middleware.
+    //
+    // Specifies that the user-accessible application URL to
+    // logout should be mounted at /logout
+    //
+    // Specifies that Keycloak console callbacks should target the
+    // root URL.  Various permutations, such as /k_logout will ultimately
+    // be appended to the admin URL.
+
+    app.use(keycloak.middleware({
+      logout: '/logout',
+      admin: '/'
+    }));
+
+    app.get('/login', keycloak.protect(), function (req, res) {
+      output(res, JSON.stringify(JSON.parse(req.session['keycloak-token']), null, 4), 'Auth Success');
+    });
+
+    app.get('/check-sso', keycloak.checkSso(), function (req, res) {
+      var authenticated = 'Check SSO Success (' + (req.session['keycloak-token'] ? 'Authenticated' : 'Not Authenticated') + ')';
+      output(res, authenticated);
+    });
+
+    app.get('/restricted', keycloak.protect('realm:admin'), function (req, res) {
+      var user = req.kauth.grant.access_token.content.preferred_username;
+      output(res, user, 'Restricted access');
+    });
+
+    app.get('/service/admin', keycloak.protect('realm:admin'), function (req, res) {
+      res.json({ message: 'admin' });
+    });
+
+    app.get('/service/grant', keycloak.protect(), (req, res, next) => {
+      keycloak.getGrant(req, res)
+        .then(grant => {
+          res.json(grant);
+        })
+        .catch(next);
+    });
+
+    app.post('/service/grant', bodyParser.json(), (req, res, next) => {
+      if (!req.body.username || !req.body.password) {
+        res.status(400).send('Username and password required');
+      }
+      keycloak.obtainDirectly(req.body.username, req.body.password)
+        .then(grant => {
+          keycloak.storeGrant(grant, req, res);
+          res.json(grant);
+        })
+        .catch(next);
+    });
+  };
+}
+
+function output (res, output, eventMessage, page) {
+  page = page || 'index';
+  res.render(page, {
+    result: output,
+    event: eventMessage
+  });
+}
+
+module.exports = {
+  NodeApp: NodeApp
+};

--- a/test/keycloak-connect-rest-mixed-client-restify-spec.js
+++ b/test/keycloak-connect-rest-mixed-client-restify-spec.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const admin = require('./utils/realm');
+const NodeApp = require('./fixtures/node-console/restify').NodeApp;
+
+const test = require('blue-tape');
+const axios = require('axios');
+const getToken = require('./utils/token');
+
+const realmName = 'mixed-mode-realm';
+const realmManager = admin.createRealm(realmName);
+const app = new NodeApp();
+
+const auth = {
+  username: 'test-admin',
+  password: 'password'
+};
+
+test('setup', t => {
+  return realmManager.then(() => {
+    return admin.createClient(app.confidential(), realmName)
+      .then((installation) => {
+        return app.build(installation);
+      });
+  });
+});
+
+test('Should test protected route.', t => {
+  t.plan(1);
+  const opt = {
+    url: `${app.address}/service/admin`
+  };
+  return t.shouldFail(axios(opt), 'Access denied', 'Response should be access denied for no credentials');
+});
+
+test('Should test protected route with admin credentials.', t => {
+  t.plan(1);
+  return getToken({ realmName }).then((token) => {
+    const opt = {
+      url: `${app.address}/service/admin`,
+      headers: { Authorization: `Bearer ${token}` }
+    };
+    return axios(opt)
+      .then(response => {
+        t.equal(response.data.message, 'admin');
+      })
+      .catch(error => {
+        t.fail(error.response.data);
+      });
+  });
+});
+
+test('Should test protected route with invalid access token.', t => {
+  t.plan(1);
+  return getToken({ realmName }).then((token) => {
+    const opt = {
+      url: `${app.address}/service/admin`,
+      headers: {
+        Authorization: 'Bearer ' + token.replace(/(.+?\..+?\.).*/, '$1.Invalid')
+      }
+    };
+    return t.shouldFail(axios(opt), 'Access denied', 'Response should be access denied for invalid access token');
+  });
+});
+
+test('Should handle direct access grants.', t => {
+  t.plan(3);
+  return axios.post(`${app.address}/service/grant`, auth)
+    .then(response => {
+      t.ok(response.data.id_token, 'Response should contain an id_token');
+      t.ok(response.data.access_token, 'Response should contain an access_token');
+      t.ok(response.data.refresh_token, 'Response should contain an refresh_token');
+    })
+    .catch(error => {
+      t.fail(error.response.data);
+    });
+});
+
+test('Should verify during authentication if the token contains the client name as audience.', t => {
+  t.plan(3);
+  const someapp = new NodeApp();
+  var client = admin.createClient(someapp.confidential('audience-app'), realmName);
+
+  return client.then((installation) => {
+    installation.verifyTokenAudience = true;
+    someapp.build(installation);
+
+    return axios.post(`${someapp.address}/service/grant`, auth)
+      .then(response => {
+        t.ok(response.data.id_token, 'Response should contain an id_token');
+        t.ok(response.data.access_token, 'Response should contain an access_token');
+        t.ok(response.data.refresh_token, 'Response should contain an refresh_token');
+      })
+      .catch(error => {
+        t.fail(error.response.data);
+      });
+  }).then(() => {
+    someapp.destroy();
+  });
+});
+
+test('teardown', t => {
+  return realmManager.then((realm) => {
+    app.destroy();
+    admin.destroy(realmName);
+  });
+});


### PR DESCRIPTION
### Using restify in node-connect, fails to redirect the client with the following error

`Exception has occurred: AssertionError [ERR_ASSERTION]: res.redirect() requires a next param (func) is required`
Alongside with this, I noticed some params from the request object are not collected correctly, that'd be the host, protocol and port. 

And took the chance to update the deprecated method for express.js: redirect now needs a `status code`

### To reproduce: 
 - use restify instead of express js
 - call the protect() function in a request

#### JIRA Ticket:
 https://issues.redhat.com/browse/KEYCLOAK-16726