### PR TITLE
Keep track of error of grantAttacher

### DIFF
--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -21,6 +21,10 @@ module.exports = function (keycloak) {
       .then(grant => {
         request.kauth.grant = grant;
       })
-      .then(next).catch(() => next());
+      .then(next)
+      .catch(error => {
+        request.kauth.error = error;
+        next()
+      });
   };
 };


### PR DESCRIPTION
It can be very useful to keep track of the error and send ad hoc error message back to requester!

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
