### PR TITLE
Keep track of error of grantManager.createGrant

### DIFF
--- a/keycloak.js
+++ b/keycloak.js
@@ -327,7 +327,7 @@ Keycloak.prototype.getGrant = function (request, response) {
         self.storeGrant(grant, request, response);
         return grant;
       })
-      .catch(() => { return Promise.reject(new Error('Could not store grant code error')); });
+      .catch(error => { return Promise.reject(error); });
   }
 
   return Promise.reject(new Error('Could not obtain grant code error'));


### PR DESCRIPTION
It can be very useful to keep track of the error and send ad hoc error message back to requester!

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
