### PR TITLE
Updated as per KEYCLOAK-18141

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - name: Check out the code
       uses: actions/checkout@v2


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-18141

The current NodeJS release page as of 18-May-2021 (https://nodejs.org/en/about/releases/) indicates the following:

Release  | Status                | Codename | Initial Release | Active LTS Start | Maintenance LTS Start | End-of-life
--------+-----------------+-----------+--------------+----------------+-----------------------+-------------
 v12      | Maintenance LTS | Erbium       |  2019-04-23  |    2019-10-21  |    2020-11-30         | 2022-04-30
 v14      | Active LTS            | Fermium    |  2020-04-21  |    2020-10-27  |    2021-10-19         | 2023-04-30
 v15      | Current               |                   |  2020-10-20  |                         |    2021-04-01         | 2021-06-01
 v16      | Current               |                   |  2021-04-20  |    2021-10-26  |    2022-10-18         | 2024-04-30



As 11 and 13 are not supported they should be replaced with 14 and 16. NodeJS 10 is just about or has just gone EOL in the last few weeks, so it has been removed.

