### PR TITLE
KEYCLOAK-18130 - Migrate to eslint from jshint so linting can work on non Unix OS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "env": {
+    "node": true,
+    "browser": true,
+    "es6": true
+  },
+  "parserOptions": {
+     "ecmaFeatures": {
+       "jsx": true
+    },
+    "ecmaVersion": 8,
+    "sourceType": "module"
+  },
+  "globals": {
+    "request": true,
+    "appRoot": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "rules": {
+    "strict": "off",
+    "no-debugger": "off",
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-this-alias": "off"
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
   },
   "extends": [
     "eslint:recommended",
+    "semistandard",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended"
   ],
@@ -27,10 +28,28 @@
   "rules": {
     "strict": "off",
     "no-debugger": "off",
+    "semi": [2, "always"],
+    "indent": ["warn", 2],
+    "no-multi-spaces": [1],
+    "keyword-spacing": 1,
+    "prefer-const": "off",
+    "quote-props": "off",
+
+    "no-trailing-spaces" : "warn",
+    "no-var": "warn",
+    "computed-property-spacing": "warn",
+    "array-bracket-spacing": "warn",
+    "no-multiple-empty-lines": "warn",
+    "camelcase": "warn",
+    "no-use-before-define": "warn",
+    "node/no-deprecated-api": "warn",
+    "dot-notation": "warn",
+
     "@typescript-eslint/no-var-requires": "off",
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-unused-vars": "off",
-    "@typescript-eslint/no-empty-function": "off",
-    "@typescript-eslint/no-this-alias": "off"
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-empty-function": "warn",
+    "@typescript-eslint/no-this-alias": "warn"
+
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pid.txt
 .idea/
 tmp/
 .vscode/
+package-lock.json
+yarn.lock

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,0 @@
-{
-  "asi" : false,
-  "esversion": 6,
-  "node": true
-}

--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -1,6 +1,6 @@
-import * as express from 'express'
+import * as express from 'express';
 
-/**
+/*
  * The JavaScript module is exported as a single function, but for TypeScript we
  * need to export the function and a set of interfaces so developers can assign
  * types such as Grant, Token, etc. to variables in their own code.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://keycloak.org",
   "main": "keycloak.js",
   "scripts": {
-    "lint": "jshint *.js stores/*.js middleware/*.js middleware/auth-utils/*.js example/*.js",
+    "lint": "eslint *.js *.ts example/**/*.js middleware/**/*.js stores/**/*.js test/**/*.js",
     "format": "semistandard",
     "test": "./run-tests.sh",
     "docs": "jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./middleware/*.js stores/*.js ./middleware/auth-utils/*.js",
@@ -38,17 +38,20 @@
     "jwk-to-pem": "^2.0.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.23.0",
+    "@typescript-eslint/parser": "^4.23.0",
     "axios": "^0.21.1",
     "blue-tape": "^1.0.0",
     "body-parser": "^1.13.3",
+    "cookie-parser": "^1.4.5",
     "coveralls": "^3.0.1",
+    "eslint": "^7.26.0",
+    "eslint-plugin-react": "^7.23.2",
     "express": "^4.14.0",
     "express-session": "^1.14.2",
-    "cookie-parser": "^1.4.5",
     "hogan-express": "^0.5.2",
     "ink-docstrap": "^1.1.4",
     "jsdoc": "^3.6.3",
-    "jshint": "^2.10.2",
     "keycloak-admin-client": "bucharest-gold/keycloak-admin-client",
     "keycloak-request-token": "^0.1.0",
     "nock": "^12.0.3",
@@ -59,7 +62,8 @@
     "server-destroy": "^1.0.1",
     "tap-xunit": "^2.4.1",
     "tape": "^4.6.3",
-    "tape-catch": "^1.0.6"
+    "tape-catch": "^1.0.6",
+    "typescript": "^4.2.4"
   },
   "optionalDependencies": {
     "chromedriver": "latest"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.23.0",
+    "@typescript-eslint/experimental-utils": "^4.24.0",
     "@typescript-eslint/parser": "^4.23.0",
     "axios": "^0.21.1",
     "blue-tape": "^1.0.0",
@@ -46,6 +47,7 @@
     "cookie-parser": "^1.4.5",
     "coveralls": "^3.0.1",
     "eslint": "^7.26.0",
+    "eslint-config-semistandard": "^15.0.1",
     "eslint-plugin-react": "^7.23.2",
     "express": "^4.14.0",
     "express-session": "^1.14.2",


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-18130

**KEYCLOAK-18130 Description - relevant info**
_The node package jshint does not glob on Windows and therefore does not work on Windows, which causes the "npm run lint" to fail on windows. There is no workar round for this without changing to another linter or  making changes to jshint in a PR.

There are a few of issues already raised about windows globing on https://github.com/jshint/jshint/issues   , but these have not been resolved w.r.t. fixing them.

 

I suggest moving to eslint as it works on windows, Linux and macOS. If this is okay please let me know and I will do the work required just to to fix running "npm run lint" on a windows on the command line._

So this PR is to migrate from jshint to eslint.  Please be aware that the .eslintrc.json file may contain linting conditions that IMHO should be enabled, but are disabled/downgraded to warnings in order to match the faults/non faults semistandard fails on.