### PR TITLE
KEYCLOAK-18134 - fix package.json 'coverage' script fails to run 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "semistandard",
     "test": "./run-tests.sh",
     "docs": "jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./middleware/*.js stores/*.js ./middleware/auth-utils/*.js",
-    "coverage": "nyc cover tape test/unit/*.js tape test/*.js"
+    "coverage": "nyc tape test/unit/*.js tape test/*.js"
   },
   "keywords": [
     "sso",
@@ -41,10 +41,10 @@
     "axios": "^0.21.1",
     "blue-tape": "^1.0.0",
     "body-parser": "^1.13.3",
+    "cookie-parser": "^1.4.5",
     "coveralls": "^3.0.1",
     "express": "^4.14.0",
     "express-session": "^1.14.2",
-    "cookie-parser": "^1.4.5",
     "hogan-express": "^0.5.2",
     "ink-docstrap": "^1.1.4",
     "jsdoc": "^3.6.3",


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-18134

When you run the "npm run coverage" script it fails with the following error on ubunto 20.04:

> keycloak-connect@14.0.0-dev coverage /home/ubuntu/Code/keycloak-nodejs-connect
> nyc cover tape test/unit/.js tape test/.js

events.js:174
throw er; // Unhandled 'error' event
^

When you run the "npm run coverage" script it fails with the following error on windows:

> keycloak-connect@14.0.0-dev coverage
> nyc cover tape test/unit/.js tape test/.js

'cover' is not recognized as an internal or external command,
operable program or batch file.
node:events:342
throw er; // Unhandled 'error' event

 

Removing 'cover' from the package.json coverage script lets nyc start the tape testing.