### PR TITLE
KEYCLOAK-18133 - fix "npm run docs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pid.txt
 .idea/
 tmp/
 .vscode/
+docs-js/

--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,0 +1,25 @@
+{
+    "plugins": [],
+    "recurseDepth": 10,
+    "source": {
+        "include": ["README.md", "."],
+        "includePattern": "\\.js$",        
+        "exclude": ["node_modules","docs","example","product","scripts","test"]
+    },
+    "sourceType": "module",
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc","closure"]
+    },
+    "templates": {
+        "cleverLinks": false,
+        "monospaceLinks": false
+    },
+    "opts": {
+        "template": "node_modules/ink-docstrap/template",
+        "encoding": "utf8",
+        "destination": "docs-js",
+        "recurse": true,
+        "verbose": true
+    }    
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "jshint *.js stores/*.js middleware/*.js middleware/auth-utils/*.js example/*.js",
     "format": "semistandard",
     "test": "./run-tests.sh",
-    "docs": "jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./middleware/*.js stores/*.js ./middleware/auth-utils/*.js",
+    "docs": "rimraf docs-js && jsdoc -c .jsdoc.json",
     "coverage": "nyc cover tape test/unit/*.js tape test/*.js"
   },
   "keywords": [
@@ -41,10 +41,10 @@
     "axios": "^0.21.1",
     "blue-tape": "^1.0.0",
     "body-parser": "^1.13.3",
+    "cookie-parser": "^1.4.5",
     "coveralls": "^3.0.1",
     "express": "^4.14.0",
     "express-session": "^1.14.2",
-    "cookie-parser": "^1.4.5",
     "hogan-express": "^0.5.2",
     "ink-docstrap": "^1.1.4",
     "jsdoc": "^3.6.3",
@@ -53,6 +53,7 @@
     "keycloak-request-token": "^0.1.0",
     "nock": "^12.0.3",
     "nyc": "^15.0.0",
+    "rimraf": "^3.0.2",
     "rsa-compat": "^2.0.8",
     "selenium-webdriver": "^3.6.0",
     "semistandard": "^13.0.1",


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-18133
Package.json "docs" script fails due to non existent files in the jsdoc parameter list and glob issues.

I propose to fix this by:

1) adding a .jsdoc.json file

2) Changing the package.json docs script to be:

"docsNew": "rimraf docs-js && jsdoc -c .jsdoc.json",

3) Add rimraf for it's ability to delete directory trees on multiple platforms and file systems.

ALSO when implementing this the docs now go into the docs-js directory instead of into the existing docs directory. This indicates to me that no one has looked at the docs creation for a long time.
