### PR TITLE
KEYCLOAK-18131 Add support for Windows to spin up docker instead of using bash as there is no bash installed by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+version: "3.7"
+
+services:
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:12.0.4
+    hostname: keycloak
+    container_name: keycloak
+    restart: unless-stopped
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+      KEYCLOAK_HTTPS_PORT: 8443
+      JAVA_OPTS: "-Djboss.as.management.blocking.timeout=3600"
+      #------------------------------------------------------------------------------------------------------------
+      # Export Realm, see https://hub.docker.com/r/jboss/keycloak/
+      #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+      # Import Realm, see https://hub.docker.com/r/jboss/keycloak/
+      # KEYCLOAK_IMPORT: /config/nodejs-test-realm.json 
+      #------------------------------------------------------------------------------------------------------------
+    command:
+      # see https://stackoverflow.com/questions/61184888/how-to-import-multiple-realm-in-keycloak
+      - "-b 0.0.0.0"
+      - "-Dkeycloak.migration.action=import"
+      - "-Dkeycloak.migration.provider=singleFile"
+      - "-Dkeycloak.migration.file=/config/nodejs-test-realm.json"
+      - "-Dkeycloak.migration.strategy=IGNORE_EXISTING"
+    volumes:
+      - ./test/fixtures/auth-utils/nodejs-test-realm.json:/config/nodejs-test-realm.json 
+    ports:
+      - 8080:8080
+      - 8443:8443
+      - 9990:9990
+    healthcheck:
+      test: "curl -f http://localhost:8080/auth || exit 1"
+      start_period: 10s
+
+
+# ------------------------------------------------------------------------------------------------------------------------------------
+# http://localhost:8080/auth/admin/master/console
+# ------------------------------------------------------------------------------------------------------------------------------------
+# DOCKER WINDOWS PORT BINDING ERROR
+# =====================================
+# ERROR: 
+# ------  
+#     Ports are not available: listen tcp 0.0.0.0:8022: 
+#     bind: An attempt was made to access a socket in a way forbidden by its access permissions
+#
+# SOLUTION:
+# ---------
+# from admin command prompt run the following two commands:
+# sc stop winnat
+#
+# Notes:
+# sc qc winnat
+# sc query winnat
+# "C:\Program Files\Docker\Docker\Docker Desktop.exe"
+# DO NOT "sc config WinNat start=demand" as docker will crash on startup!!!
+# ------------------------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------------------------------------------------------

--- a/docs/tests-development.md
+++ b/docs/tests-development.md
@@ -1,11 +1,15 @@
 ## Writing tests
 
-When writing tests please follow the same approach as we have taken in the other tests. There are many ways to 
-test software and we have chosen ours, so please appreciate that.
+When writing tests please follow the same approach as we have taken in the other tests. There are many ways to test software and we have chosen ours, so please appreciate that.
+
+You will need docker installed to be able to spin up the keycloak container that the tests require.
 
 The main tests are provided in `test` folder. Before executing them, first make sure that the Keycloak server was started to run all the integration tests:
 
     ./scripts/start-server.sh
+
+    or on Windows run the following command
+    docker-compose up -d keycloak
 
 Running all the tests:
 
@@ -17,3 +21,9 @@ Running specific tests:
 When developing your test depending on the feature or enhancement you are testing you may find it best to add to an
 existing test, or to write a test from scratch. For the latter, we recommend finding another test that is close to what 
 you need and use that as a basis.
+
+To stop the docker keycloak container run the following:
+    docker stop keycloak
+
+To remove the docker keycloak container run the following:
+    docker rm keycloak


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-18131

By default Windows does not include a bash shell and as such you cannot run by default either of the following scripts on Windows:

scripts/start-server.sh
scripts/stop-server.sh

 
I propose to add a docker-compose/yml and update the docs to add in the appropriate commands to create the docker keycloak container and also stop & destroy it
