### PR TITLE
Add credentials.secret to KeycloakConfig interface

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -24,6 +24,9 @@ declare namespace KeycloakConnect {
     'ssl-required': string
     'bearer-only'?: boolean
     realm: string
+    credentials?: {
+      secret: string
+    }
   }
 
   interface KeycloakOptions {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

I keep finding myself extending `KeycloakConfig` in my projects so I can pass in my confidential client secrets cleanly. Figured I should take a minute and make the change here 😄 