### PR TITLE
Add token property to Token interface

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -45,6 +45,7 @@ declare namespace KeycloakConnect {
     hasRole(roleName: string): boolean
     hasApplicationRole(appName: string, roleName: string): boolean
     hasRealmRole(roleName: string): boolean
+    token: string
   }
 
   interface GrantManager {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Similar to #289, adding another missing property to the type definitions. This one gives TS users (clean) access to the raw value of a `Token`.