### PR TITLE
Use an object to describe permission instead of strings

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -41,10 +41,15 @@ declare namespace KeycloakConnect {
   }
 
   interface Token {
-    isExpired(): boolean
-    hasRole(roleName: string): boolean
-    hasApplicationRole(appName: string, roleName: string): boolean
-    hasRealmRole(roleName: string): boolean
+    isExpired(): boolean;
+    hasRole(roleName: string): boolean;
+    hasApplicationRole(appName: string, roleName: string): boolean;
+    hasRealmRole(roleName: string): boolean;
+  }
+
+  interface Permission {
+    resource: string;
+    scope?: string;
   }
 
   interface GrantManager {
@@ -344,7 +349,10 @@ declare namespace KeycloakConnect {
      *
      * @param {string[]} permissions A single string representing a permission or an arrat of strings representing the permissions. For instance, 'item:read' or ['item:read', 'item:write'].
      */
-    enforcer(permissions: string[]|string, config?: EnforcerOptions): express.RequestHandler
+    enforcer(
+      permissions: Permission[] | string | string[] | string[][],
+      config?: EnforcerOptions
+    ): express.RequestHandler;
 
     /**
      * Apply check SSO middleware to an application or specific URL.

--- a/middleware/enforcer.js
+++ b/middleware/enforcer.js
@@ -17,12 +17,24 @@
 
 function handlePermissions (permissions, callback) {
   for (let i = 0; i < permissions.length; i++) {
-    const expected = permissions[i].split(':');
-    const resource = expected[0];
+    const permission = permissions[i];
+    
+    let resource;
     let scope;
-
-    if (expected.length > 1) {
-      scope = expected[1];
+    if (typeof permission === 'string') {
+      const parts = permission.split(':');
+      resource = parts[0];
+      if (parts.length > 1) {
+        scope = parts[1];
+      } 
+    } else if (Array.isArray(permission)) {
+      resource = permission[0];
+      if (permission.length > 1) {
+        scope = permission[1];
+      } 
+    } else if (typeof permission === 'object') {
+      resource = permission.resource;
+      scope = permission.scope || undefined;
     }
 
     let r = callback(resource, scope);


### PR DESCRIPTION
Hey folks, I noticed that we should use something like `resource:scope` for specifying the resources and scopes we want to enforce the user has access to. Although splitting a string based on `:` might not work depending on the resource name. If you are using your own URN, as an example, it would yield weird auth requests. 

I think extending the current format to accept resource and scope as an object or an array of string arrays might easily solve that 