### PR TITLE
[KEYCLOAK-17490] Add override ISS

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -20,6 +20,7 @@ declare namespace KeycloakConnect {
   interface KeycloakConfig {
     'confidential-port': string|number
     'auth-server-url': string
+    'iss' : string
     'resource': string
     'ssl-required': string
     'bearer-only'?: boolean

--- a/middleware/auth-utils/config.js
+++ b/middleware/auth-utils/config.js
@@ -131,6 +131,12 @@ Config.prototype.configure = function configure (config) {
   this.realmUrl = this.authServerUrl + '/realms/' + this.realm;
 
   /**
+   * Token Issuer Override.
+   * @type {String}
+   */
+  this.iss = (resolveValue(config['iss'] || config.iss || this.realmUrl));
+
+  /**
    * Root realm admin URL.
    * @type {String} */
   this.realmAdminUrl = this.authServerUrl + '/admin/realms/' + this.realm;

--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -33,6 +33,7 @@ var Rotation = require('./rotation');
  */
 function GrantManager (config) {
   this.realmUrl = config.realmUrl;
+  this.iss = config.iss;
   this.clientId = config.clientId;
   this.secret = config.secret;
   this.publicKey = config.publicKey;
@@ -424,7 +425,7 @@ GrantManager.prototype.validateToken = function validateToken (token, expectedTy
       reject(new Error('invalid token (wrong type)'));
     } else if (token.content.iat < this.notBefore) {
       reject(new Error('invalid token (stale token)'));
-    } else if (token.content.iss !== this.realmUrl) {
+    } else if (token.content.iss !== this.iss) {
       reject(new Error('invalid token (wrong ISS)'));
     } else {
       var audienceData = Array.isArray(token.content.aud) ? token.content.aud : [token.content.aud];

--- a/test/fixtures/auth-utils/keycloak-frontend-url.json
+++ b/test/fixtures/auth-utils/keycloak-frontend-url.json
@@ -1,0 +1,11 @@
+{
+  "server-url" : "http://localhost:8080/auth",
+  "realm" : "nodejs-test",
+  "min-time-between-jwks-requests" : 0,
+  "resource" : "confidential-client",
+  "secret": "62b8de48-672e-4287-bb1e-6af39aec045e",
+  "iss": "http://10.0.2.2:8080/auth/realms/nodejs-test",
+  "bearerOnly": true,
+  "public-client" : false,
+  "verify-token-audience" : true
+}

--- a/test/grant-manager-spec.js
+++ b/test/grant-manager-spec.js
@@ -533,6 +533,19 @@ test('GrantManager should be able to validate invalid ISS', (t) => {
     .then(t.end);
 });
 
+test('GrantManager should be able to validate overridden ISS', (t) => {
+  const frontendManager = getManager('./test/fixtures/auth-utils/keycloak-frontend-url.json');
+  manager.obtainDirectly('test-user', 'tiger')
+    .then((grant) => {
+      grant.access_token.content.iss = 'http://10.0.2.2:8080/auth/realms/nodejs-test';
+      return frontendManager.validateGrant(grant);
+    })
+    .then((grant) => {
+      t.notEqual(grant, undefined);
+    })
+    .then(t.end);
+});
+
 test('GrantManager should be able to validate invalid iat', (t) => {
   manager.obtainDirectly('test-user', 'tiger')
     .then((grant) => {

--- a/test/unit/hconfig-test.js
+++ b/test/unit/hconfig-test.js
@@ -47,6 +47,21 @@ test('Config#configure with env variable reference set with fallback', (t) => {
   t.end();
 });
 
+test('Config#configure with iss variable set iss', (t) => {
+  let iss = 'http://10.0.2.2:8080/auth/realms/realm';
+  let cfg = new Config({ 'iss': iss });
+
+  t.equal(cfg.iss, iss);
+  t.end();
+});
+
+test('Config#configure without iss variable fallback to realmUrl', (t) => {
+  let cfg = new Config({ 'authServerUrl': 'http://localhost:8080/auth', 'realm': '${env.USER}' });
+
+  t.equal(cfg.iss, cfg.realmUrl);
+  t.end();
+});
+
 test('Config#configure with realm-public-key', (t) => {
   t.plan(2);
   RSA.generateKeypair(2048, 65537, { public: true, pem: true }, (err, keyz) => {


### PR DESCRIPTION
This feature will allow you to override the ISS validation.


Currently the library isn't respecting the `FRONTEND_URL` configurationof keycloak which will give you a different issuer than the backend server url