### PR TITLE
 KEYCLOAK-19343 propagate error message from token validation to calling code

### DIFF
--- a/keycloak.js
+++ b/keycloak.js
@@ -326,8 +326,7 @@ Keycloak.prototype.getGrant = function (request, response) {
       .then(grant => {
         self.storeGrant(grant, request, response);
         return grant;
-      })
-      .catch(() => { return Promise.reject(new Error('Could not store grant code error')); });
+      });
   }
 
   return Promise.reject(new Error('Could not obtain grant code error'));


### PR DESCRIPTION
`keycloak.getGrant()` method does not propagate error message from `grantManager.createGrant()` but it creates new error with generic message "Could not store grant code error", which is misleading and doesn't help to troubleshoot what is going on in case of problems. `createGrant()` perform token validation and there may be many reasons why it can fail and it is necessary to see what is going.