### PR TITLE
Remove .npmignore in favor of 'files' field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-node_modules
-.idea


### PR DESCRIPTION
We're already using the 'files' field in the package to explicitly include the files in the final package, so this file can be removed.