### PR TITLE
provide options to cookie storage

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -30,6 +30,7 @@ declare namespace KeycloakConnect {
     scope?: string
     store?: any
     cookies?: boolean
+    cookieOptions?: express.CookieOptions
   }
 
   interface GrantProperties {

--- a/keycloak.js
+++ b/keycloak.js
@@ -80,7 +80,7 @@ function Keycloak (config, keycloakConfig) {
   if (config && config.store) {
     this.stores.push(new SessionStore(config.store));
   } else if (config && config.cookies) {
-    this.stores.push(CookieStore);
+    this.stores.push(CookieStore(config.cookieOptions));
   }
 
   this.config.idpHint = config.idpHint;

--- a/stores/cookie-store.js
+++ b/stores/cookie-store.js
@@ -15,7 +15,9 @@
  */
 'use strict';
 
-let CookieStore = {};
+function CookieStore(cookieOptions) {
+  this.cookieOptions = cookieOptions;
+}
 
 CookieStore.TOKEN_KEY = 'keycloak-token';
 
@@ -31,8 +33,9 @@ CookieStore.get = (request) => {
 };
 
 let store = (grant) => {
+  const self = this;
   return (request, response) => {
-    response.cookie(CookieStore.TOKEN_KEY, grant.__raw);
+    response.cookie(CookieStore.TOKEN_KEY, grant.__raw, self.cookieOptions);
   };
 };
 


### PR DESCRIPTION
Allow user to provide custom options for cookie storage like httpOnly mode or custom expiration date:

```ts
const keycloak = new Keycloak(
        { 
            cookies: true,
            cookieOptions: { maxAge: 900000, httpOnly: true },
        },
        {
            realm: 'example',
            // ...
        }
};
```
