### PR TITLE
add support for async guard function

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -192,7 +192,7 @@ declare namespace KeycloakConnect {
     isExpired(): boolean
   }
 
-  type GuardFn = (accessToken: Token, req: express.Request, res: express.Response) => boolean
+  type GuardFn = (accessToken: Token, req: express.Request, res: express.Response) => boolean|Promise<boolean>
 
   interface EnforcerOptions {
     response_mode?: string,

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -50,11 +50,21 @@ module.exports = function (keycloak, spec) {
 
   return function protect (request, response, next) {
     if (request.kauth && request.kauth.grant) {
-      if (!guard || guard(request.kauth.grant.access_token, request, response)) {
-        return next();
+      const guardedResponse = guard && guard(request.kauth.grant.access_token, request, response);
+      if (guardedResponse instanceof Promise) {
+        return guardedResponse
+            .then(function (authorized) {
+              return authorized ? next() : keycloak.accessDenied(request, response, next);
+            })
+            .catch(function () {
+              return keycloak.accessDenied(request, response, next);
+            });
+      } else {
+        if (!guard || guardedResponse) {
+          return next();
+        }
+        return keycloak.accessDenied(request, response, next);
       }
-
-      return keycloak.accessDenied(request, response, next);
     }
 
     if (keycloak.redirectToLogin(request)) {


### PR DESCRIPTION
Reviving the following old PR as I'm hitting the same issue:
https://github.com/keycloak/keycloak-nodejs-connect/pull/97
https://issues.redhat.com/browse/KEYCLOAK-5771?workflowName=GIT+Pull+Request+workflow+&stepId=4

I need to use an async GuardFn for my application.

I tested with a simple setTimeout method:
```
const keycloakGuardFn: KeycloakConnect.GuardFn = async (accessToken: Token, req: express.Request): Promise<boolean> => {
    const sleep = async (ms: number) => {
        return new Promise((resolve) => setTimeout(resolve, ms));
    }
    logger.trace("Sleeping for 2 seconds");
    await sleep(2000);
    logger.trace("Sleep finished");
    return true;
}
```

Looks fine in my testing. 

Do I need to update the unit tests? I'm not too sure where/what to add here.

Cheers