### PR TITLE
Drop support for Node.js version 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["12", "14", "16"]
+        node-version: ["14", "16"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,10 +40,10 @@
         "tar-fs": "^2.1.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "optionalDependencies": {
-        "chromedriver": "*"
+        "chromedriver": "latest"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -546,6 +546,15 @@
         "query-string": "^7.0.1",
         "url-join": "^4.0.0",
         "url-template": "^2.0.8"
+      }
+    },
+    "node_modules/@keycloak/keycloak-admin-client/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8306,6 +8315,17 @@
         "query-string": "^7.0.1",
         "url-join": "^4.0.0",
         "url-template": "^2.0.8"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     ]
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Drops support for Node.js version 12 as it is [no longer](https://nodejs.org/en/about/releases/) an actively maintained LTS.