### PR TITLE
Remove extra step when running test server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,6 @@ jobs:
           distribution: temurin
           java-version: 11
 
-      - name: Import test realm
-        run: npm run server:import-test-realm
-
       - name: Start Keycloak server
         run: npm run server:start &
 

--- a/docs/tests-development.md
+++ b/docs/tests-development.md
@@ -6,7 +6,6 @@ test software and we have chosen ours, so please appreciate that.
 The main tests are provided in `test` folder. Before executing them, first make sure that the Keycloak server was started to run all the integration tests:
 
 ```bash
-npm run server:import-test-realm
 npm run server:start
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "test": "./run-tests.sh",
     "docs": "jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./middleware/*.js stores/*.js ./middleware/auth-utils/*.js",
     "coverage": "nyc cover tape test/unit/*.js tape test/*.js",
-    "server:import-test-realm": "./scripts/start-server.mjs -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file=test/fixtures/auth-utils/nodejs-test-realm.json -Dkeycloak.migration.strategy=OVERWRITE_EXISTING",
-    "server:start": "./scripts/start-server.mjs -Dkeycloak.profile.feature.account_api=disabled -Dkeycloak.profile.feature.account2=disabled"
+    "server:start": "./scripts/start-server.mjs -Dkeycloak.profile.feature.account_api=disabled -Dkeycloak.profile.feature.account2=disabled -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file=test/fixtures/auth-utils/nodejs-test-realm.json -Dkeycloak.migration.strategy=OVERWRITE_EXISTING"
   },
   "keywords": [
     "sso",


### PR DESCRIPTION
The Keycloak server will keep running even when importing the test realm. This means this no longer needs to be a separate step.