### PR TITLE
some parameters in the constructor type are not clear at all

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -19,11 +19,49 @@ declare namespace KeycloakConnect {
 
   interface KeycloakConfig {
     'confidential-port': string|number
-    'auth-server-url': string
-    'resource': string
-    'ssl-required': string
+    /**
+     * any of these is for keycloak server endpoint
+     */
+    'auth-server-url'?: string
+    'server-url'?: string
+    serverUrl?: string
+    authServerUrl?: string
+
+    /**
+     * any of these is for client id
+     */
+    'client-id'?: string
+    clientId?: string;
+    'resource'?: string
+    
+    /**
+     * use these in case of confidential client
+     */
+    credentials?: {
+      secret: string
+    },
+    secret?: string
+    
+    /**
+     * set to true in case client is public
+     */
+    'public-client'?: boolean
+    public?: boolean
+    
+    /**
+     * set to true in case client is bearer only
+     */
     'bearer-only'?: boolean
+    bearerOnly?: boolean
+
+    'min-time-between-jwks-requests'?: number
+    minTimeBetweenJwksRequests?: number
+
+    'ssl-required': string
     realm: string
+
+    'realm-public-key'?: string
+    realmPublicKey?: string
   }
 
   interface KeycloakOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "17.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "chromedriver": "latest",
         "jwk-to-pem": "^2.0.0"
       },
       "devDependencies": {


### PR DESCRIPTION
before this fix it was pretty confusing how to
configure the constructor.
the underlying library uses all these parameters
so the user should be able to specify them since
it's also easier to understand (e.g. resource=client)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
