### PR TITLE
Include redirectUrl even if idTokenHint is not provided

### DIFF
--- a/keycloak.js
+++ b/keycloak.js
@@ -403,8 +403,11 @@ Keycloak.prototype.loginUrl = function (uuid, redirectUrl) {
 Keycloak.prototype.logoutUrl = function (redirectUrl, idTokenHint) {
   const url = new URL(this.config.realmUrl + '/protocol/openid-connect/logout')
 
-  if (redirectUrl && idTokenHint) {
+  if (idTokenHint) {
     url.searchParams.set('id_token_hint', idTokenHint)
+  }
+
+  if (redirectUrl) {
     url.searchParams.set('post_logout_redirect_uri', redirectUrl)
   }
 

--- a/test/unit/keycloak-object-test.js
+++ b/test/unit/keycloak-object-test.js
@@ -70,6 +70,24 @@ test('Should verify if logout URL has the configured realm.', t => {
   t.end()
 })
 
+test('Should verify if logout URL includes passed redirect url if provided.', t => {
+  const redirectUrl = 'https://secure.foo.bar'
+  const redirectRgx = new RegExp(`post_logout_redirect_uri=${encodeURIComponent('https://secure.foo.bar')}`)
+
+  t.equal(kc.logoutUrl(redirectUrl).match(redirectRgx) !== null, true)
+  t.end()
+})
+
+test('Should verify if logout URL includes passed redirect url + id token hint if provided.', t => {
+  const idToken = 'abc123'
+  const redirectUrl = 'https://secure.foo.bar'
+  const redirectRgx = new RegExp(`post_logout_redirect_uri=${encodeURIComponent('https://secure.foo.bar')}`)
+
+  t.equal(kc.logoutUrl(redirectUrl, idToken).match(redirectRgx) !== null, true)
+  t.equal(kc.logoutUrl(redirectUrl, idToken).indexOf(idToken) > 0, true)
+  t.end()
+})
+
 test('Should generate a correct UUID.', t => {
   const rgx = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
   t.equal(rgx.test(UUID()), true)


### PR DESCRIPTION
This PR fixes what I believe is a bug in the keycloak connect client where it will ignore the redirectUrl passed to logoutUrl if no idTokenHint is provided. 

Fixes #420 