### PR TITLE
Remove status badges that are no longer updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Keycloak Node.js Adapter
 
 ![Build Status](https://github.com/keycloak/keycloak-nodejs-connect/workflows/CI/badge.svg)
-[![Dependency Status](https://img.shields.io/david/keycloak/keycloak-nodejs-connect.svg?style=flat-square)](https://david-dm.org/keycloak/keycloak-nodejs-connect)
-[![Coverage Status](https://coveralls.io/repos/github/keycloak/keycloak-nodejs-connect/badge.svg?branch=main)](https://coveralls.io/github/keycloak/keycloak-nodejs-connect?branch=main)
 
 Keycloak is an Open Source Identity and Access Management solution for modern Applications and Services.
 


### PR DESCRIPTION
Removes the status badges that are no longer updated from the README. Previously these were updated by Travis CI, but that changed when we moved to Github Actions.

These badges are not really essential, so we can simply remove them entirely.