### PR TITLE
Add a deprecation message to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ![Build Status](https://github.com/keycloak/keycloak-nodejs-connect/workflows/CI/badge.svg)
 
+> **Warning**
+> This package is deprecated and will be removed in the future. We will shortly provide more details on removal date, and recommended alternatives.
+
 Keycloak is an Open Source Identity and Access Management solution for modern Applications and Services.
 
 This repository contains the source code for the Keycloak Node.js adapter. This module makes it simple to implement a Node.js Connect-friendly


### PR DESCRIPTION
Adds the same deprecation message we've added to the NPM page to the README. This is to avoid folks from getting invested in this library, not knowing of our future plans to remove it.