### PR TITLE
Use a valid SemVer format for the SNAPSHOT version

### DIFF
--- a/scripts/start-server.mjs
+++ b/scripts/start-server.mjs
@@ -68,7 +68,7 @@ async function getNightlyAsset () {
   })
 
   return release.data.assets.find(
-    ({ name }) => name === 'keycloak-999-SNAPSHOT.tar.gz'
+    ({ name }) => name === 'keycloak-999.0.0-SNAPSHOT.tar.gz'
   )
 }
 


### PR DESCRIPTION
Changes the default version string from `999-SNAPSHOT` to `999.0.0-SNAPSHOT`. This makes it a valid version under the [Semantic Versioning](https://semver.org/) standard.

The motivation for this change is to make versioning interoperable between Maven and NPM, as the latter only allows for Semantic Versioning. This allows for simplification in the release process, as we no longer need to convert version numbers from one to the other.

For more information see https://github.com/keycloak/keycloak/issues/17335.