### PR TITLE
keycloak.js typo fixed

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -342,7 +342,7 @@ declare namespace KeycloakConnect {
           // access granted
         });
      *
-     * @param {string[]} permissions A single string representing a permission or an arrat of strings representing the permissions. For instance, 'item:read' or ['item:read', 'item:write'].
+     * @param {string[]} permissions A single string representing a permission or an array of strings representing the permissions. For instance, 'item:read' or ['item:read', 'item:write'].
      */
     enforcer(permissions: string[]|string, config?: EnforcerOptions): express.RequestHandler
 

--- a/keycloak.js
+++ b/keycloak.js
@@ -235,7 +235,7 @@ Keycloak.prototype.protect = function (spec) {
           // access granted
         });
  *
- * @param {String[]} expectedPermissions A single string representing a permission or an arrat of strings representing the permissions. For instance, 'item:read' or ['item:read', 'item:write'].
+ * @param {String[]} expectedPermissions A single string representing a permission or an array of strings representing the permissions. For instance, 'item:read' or ['item:read', 'item:write'].
  */
 Keycloak.prototype.enforcer = function (permissions, config) {
   return new Enforcer(this, config).enforce(permissions)


### PR DESCRIPTION
Typo fixed from word arrat to array in below files

- keycloak.js
- keycloak.d.ts
