### PR TITLE
Create workflows to release Node.js adapter from own repo

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,0 +1,20 @@
+name: Release Nightly
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+
+  release-nightly:
+    name: Nightly release
+    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-nodejs-connect'
+    uses: ./.github/workflows/x-release.yml
+    with:
+      gh-org: keycloak
+      branch: ${{ github.ref_name }}
+      tag: nightly
+      nightly: true
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version
+        required: true
+
+jobs:
+
+  release:
+    name: Release
+    uses: ./.github/workflows/x-release.yml
+    with:
+      gh-org: keycloak
+      branch: ${{ github.ref_name }}
+      tag: ${{ inputs.version }}
+      nightly: false
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/x-release.yml
+++ b/.github/workflows/x-release.yml
@@ -1,0 +1,153 @@
+name: X Release
+
+on:
+  workflow_call:
+    inputs:
+      gh-org:
+        required: true
+        type: string
+      branch:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      nightly:
+        required: true
+        type: boolean
+    secrets:
+      GH_TOKEN:
+        required: true
+      NPM_TOKEN:
+        required: false
+
+concurrency: rel-${{ github.ref }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  show-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Github organization: ${{ inputs.gh-org }}  " >> $GITHUB_STEP_SUMMARY
+          echo "Branch: ${{ inputs.branch }}  " >> $GITHUB_STEP_SUMMARY
+          echo "Target tag: ${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
+          echo "Is nightly build: ${{ inputs.nightly }}  " >> $GITHUB_STEP_SUMMARY
+
+  create-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Create version commit
+        if: ${{ !inputs.nightly }}
+        run: |
+          ./set-version.sh ${{ inputs.tag }}
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git commit -a -m "Set version to ${{ inputs.tag }}"
+
+      - name: Tag commit
+        run: git tag --force ${{ inputs.tag }}
+
+      - name: Push changes
+        run: git push --force origin refs/tags/${{ inputs.tag }}
+
+  create-gh-releases:
+    runs-on: ubuntu-latest
+    needs: [create-tags]
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    steps:
+      - name: Check if release exists
+        id: release-exists
+        run: >
+          echo "release-exists=$(
+            if ( gh release view ${{ inputs.tag }} --repo ${{ inputs.gh-org }}/keycloak-nodejs-connect &> /dev/null ); then
+              echo 'true'
+            else
+              echo 'false'
+            fi
+          )" >> $GITHUB_ENV
+
+      - name: Create a release
+        if: env.release-exists == 'false'
+        run: gh release create ${{ inputs.tag }} --repo ${{ inputs.gh-org }}/keycloak-nodejs-connect --title ${{ inputs.tag }} --draft ${{ inputs.nightly && '--prerelease' || '' }}
+
+  release-on-github:
+    runs-on: ubuntu-latest
+    needs: [create-gh-releases]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          check-latest: true
+          cache: npm
+
+      - name: Create package tarball
+        run: |
+          npm pack
+          mv -T *.tgz keycloak-nodejs-connect.tgz
+
+      - name: Upload to GitHub Releases
+        run: |
+          for i in `gh release view ${{ inputs.tag }} --json assets --jq '.assets[].name'`; do 
+            test -f $i || gh release delete-asset ${{ inputs.tag }} $i -y
+          done
+          gh release upload ${{ inputs.tag }} keycloak-nodejs-connect.tgz --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  publish-gh-release:
+    runs-on: ubuntu-latest
+    needs: [release-on-github]
+    steps:
+      - name: Publish release
+        run: gh release edit ${{ inputs.tag }} --repo ${{ inputs.gh-org }}/keycloak-nodejs-connect --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: [release-on-github]
+    if: ${{ !inputs.nightly }}
+    steps:
+      - name: Download archive
+        run: gh release download ${{ inputs.tag }} --repo ${{ inputs.gh-org }}/keycloak-nodejs-connect --pattern 'keycloak-nodejs-connect.tgz'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          check-latest: true
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish to NPM
+        run: npm publish keycloak-nodejs-connect.tgz --access public --ignore-scripts ${{ inputs.gh-org != 'keycloak' && ' --dry-run' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+
+  show-output:
+    name: Show Output
+    runs-on: ubuntu-latest
+    needs: [create-tags,publish-gh-release]
+    steps:
+      - run: |
+          echo "https://github.com/${{ inputs.gh-org }}/keycloak-nodejs-connect/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
+          echo "https://github.com/${{ inputs.gh-org }}/keycloak-nodejs-connect/releases/tag/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
closes #520

Ability to release node.js adapter from it's own repository. PR introduces 2 workflows:
- `release nightly` - for trigger nightly releases of node.js adapter
- `release` - for trigger regular release of node.js adapter

Workflows are doing same steps like the related workflows in `keycloak-rel`. There is related PR to keycloak-rel, which removes the node.js related workflows from `keycloak-rel` : https://github.com/keycloak-rel-testing/keycloak-rel/pull/45 (So far only PR to the "testing" fork of node.js)

The workflows require 2 secrets present in the repository, which are not there yet:
`GH_TOKEN` - Token of keycloak-bot to be able to use `gh` command (needed for the manipulation with GH releases etc)
`NPM_TOKEN` - Token needed to be able to publish to npm registry like https://www.npmjs.com/package/keycloak-connect/v/26.0.7 . Needed only for `release` (not needed for `release nightly`)
