### PR TITLE
Upload documentation zip to the GitHub release

### DIFF
--- a/.github/workflows/x-release.yml
+++ b/.github/workflows/x-release.yml
@@ -77,12 +77,17 @@ jobs:
           npm pack
           mv -T *.tgz keycloak-nodejs-connect.tgz
 
+      - name: Create guides zip
+        run: |
+          npm install
+          npm run guides
+
       - name: Upload to GitHub Releases
         run: |
           for i in `gh release view ${{ inputs.tag }} --json assets --jq '.assets[].name'`; do 
             test -f $i || gh release delete-asset ${{ inputs.tag }} $i -y
           done
-          gh release upload ${{ inputs.tag }} keycloak-nodejs-connect.tgz --clobber
+          gh release upload ${{ inputs.tag }} keycloak-nodejs-connect.tgz "guides/target/keycloak-nodejs-connect-guides.zip" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/guides/guides.mjs
+++ b/guides/guides.mjs
@@ -133,7 +133,7 @@ const main = async (version) => {
   fs.cpSync(path.join(dir, 'images'), path.join(outputDir, 'images'), { recursive: true })
   fs.cpSync(path.join(dir, 'attributes.adoc'), path.join(outputDir, 'attributes.adoc'))
 
-  const zipFile = path.join(targetDir, 'keycloak-nodejs-connect-guides-' + version + '.zip')
+  const zipFile = path.join(targetDir, 'keycloak-nodejs-connect-guides.zip')
   generateZip(new JSZip(), zipFile, outputDir, targetDir)
 }
 


### PR DESCRIPTION
Closes #551

Just running the `npm run guides` and uploading the resulting artifact to the GH release.
