### PR TITLE
The draft nightly untagged release is incorrectly created by 'Release…

### DIFF
--- a/.github/workflows/x-release.yml
+++ b/.github/workflows/x-release.yml
@@ -55,20 +55,14 @@ jobs:
       - name: Push changes
         run: git push --force origin refs/tags/${{ inputs.tag }}
 
-      - name: Check if release exists
-        id: release-exists
-        run: >
-          echo "release-exists=$(
-            if ( gh release view ${{ inputs.tag }} --repo ${{ inputs.gh-org }}/keycloak-nodejs-connect &> /dev/null ); then
-              echo 'true'
-            else
-              echo 'false'
-            fi
-          )" >> "$GITHUB_OUTPUT"
-
-      - name: Create a github release
-        if: steps.release-exists.outputs.release-exists == 'false'
-        run: gh release create ${{ inputs.tag }} --repo ${{ inputs.gh-org }}/keycloak-nodejs-connect --title ${{ inputs.tag }} --draft ${{ inputs.nightly && '--prerelease' || '' }}
+      - name: Create a github release if does not exists
+        id: create-release-if-not-exists
+        run: |
+          if ( gh release view ${{ inputs.tag }} --repo ${{ inputs.gh-org }}/keycloak-nodejs-connect &> /dev/null ); then
+            echo "Release ${{ inputs.tag }} already exists"
+          else
+            gh release create ${{ inputs.tag }} --repo ${{ inputs.gh-org }}/keycloak-nodejs-connect --title ${{ inputs.tag }} --draft ${{ inputs.nightly && '--prerelease' || '' }}
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
… nightly' GH action

closes #558

There was incorrect evaluation as `steps.release-exists.outputs.release-exists == 'false'` was always evaluated to run and hence the `gh release create` was always executed and created another draft for `nightly` release.

I've simplified and merged the two steps into single one as there is no need to propagate `release-exists` as a variable (it was originally a variable just because this was copied from keycloak-rel)
