### PR TITLE
Incorrectly resolved {project_versionNpm} expression in the documenta…

### DIFF
--- a/guides/securing-apps/nodejs-adapter.adoc
+++ b/guides/securing-apps/nodejs-adapter.adoc
@@ -31,7 +31,7 @@ ifeval::[{project_community}==true]
 [source,json,subs="attributes"]
 ----
     "dependencies": {
-        "keycloak-connect": "{project_versionNpm}"
+        "keycloak-connect": "{version_nodejs_adapter}"
     }
 ----
 
@@ -42,7 +42,7 @@ ifeval::[{project_product}==true]
 [source,json,subs="attributes"]
 ----
     "dependencies": {
-        "keycloak-connect": "file:keycloak-connect-{project_versionNpm}.tgz"
+        "keycloak-connect": "file:keycloak-connect-{version_nodejs_adapter}.tgz"
     }
 ----
 

--- a/guides/templates/guide.adoc
+++ b/guides/templates/guide.adoc
@@ -7,6 +7,7 @@
 :guide-priority: ${priority}
 :guide-tile-visible: ${tileVisible}
 :version: ${version}
+:version_nodejs_adapter: ${version}
 
 include::../attributes.adoc[]
 


### PR DESCRIPTION
…tion

closes #562

PR adds the expression `version_nodejs_adapter` to the `guides.adoc`, which is replaced during `npm run guides` with the current version of the adapter . This property is consumed in the `nodejs-adapter.adoc` .

### Testing

I wanted to test the documentation rendered correctly in keycloak-web . So did this:
- Executed the `Release` and `Release nightly` workflow in my node.js fork. I've updated the organization ( Fake commit to do this https://github.com/mposolda/keycloak-nodejs-connect/commit/d0f07bfa4d667656bf20c06cf196c8f2e09b029d ) and did the `nightly` release and the fake 25.1.5 release:
  - https://github.com/mposolda/keycloak-nodejs-connect/releases/tag/25.1.5
  - https://github.com/mposolda/keycloak-nodejs-connect/releases/tag/nightly

- Run keycloak-web build with slightly modified PR https://github.com/keycloak/keycloak-web/pull/551 to make sure that it can download from my ghorganization `mposolda` instead of main organization `keycloak` .

- Checked the rendered guides by keycloak-web (both released guide and nightly guide) has correctly replaced version in the nodejs file like for example:

![Screenshot from 2025-01-24 12-34-40](https://github.com/user-attachments/assets/b405bbb2-1c8c-471a-8e9d-0cae51ef9c76)

