### PR TITLE
Add the ability to issue a certificate from a different URL than the …

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -24,6 +24,7 @@ declare namespace KeycloakConnect {
     'ssl-required': string
     'bearer-only'?: boolean
     realm: string
+    issuer: string
   }
 
   interface KeycloakOptions {

--- a/middleware/auth-utils/config.js
+++ b/middleware/auth-utils/config.js
@@ -131,6 +131,12 @@ Config.prototype.configure = function configure (config) {
   this.realmUrl = this.authServerUrl + '/realms/' + this.realm
 
   /**
+   * Token issuer override
+   * @type {String}
+   */
+  this.issuer = resolveValue(config.issuer || this.realmUrl)
+
+  /**
    * Root realm admin URL.
    * @type {String} */
   this.realmAdminUrl = this.authServerUrl + '/admin/realms/' + this.realm

--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -41,6 +41,7 @@ function GrantManager (config) {
   this.notBefore = 0
   this.rotation = new Rotation(config)
   this.verifyTokenAudience = config.verifyTokenAudience
+  this.issuer = config.issuer
 }
 
 /**
@@ -425,7 +426,7 @@ GrantManager.prototype.validateToken = function validateToken (token, expectedTy
       reject(new Error('invalid token (wrong type)'))
     } else if (token.content.iat < this.notBefore) {
       reject(new Error('invalid token (stale token)'))
-    } else if (token.content.iss !== this.realmUrl) {
+    } else if (token.content.iss !== this.issuer) {
       reject(new Error('invalid token (wrong ISS)'))
     } else {
       const audienceData = Array.isArray(token.content.aud) ? token.content.aud : [token.content.aud]

--- a/test/fixtures/auth-utils/keycloak-confidential.json
+++ b/test/fixtures/auth-utils/keycloak-confidential.json
@@ -5,5 +5,6 @@
   "resource" : "confidential-client",
   "secret": "62b8de48-672e-4287-bb1e-6af39aec045e",
   "public-client" : false,
-  "verify-token-audience" : true
+  "verify-token-audience" : true,
+  "issuer": "http://testissuer.com"
 }

--- a/test/grant-manager-spec.mjs
+++ b/test/grant-manager-spec.mjs
@@ -532,6 +532,16 @@ test('GrantManager should be able to validate invalid ISS', (t) => {
     })
 })
 
+test('GrantManager should be able to accept issuer different from the realm URL', (t) => {
+  t.plan(1)
+  manager.obtainDirectly('test-user', 'tiger')
+    .then((grant) => {
+      grant.access_token.content.iss = 'http://testissuer.com'
+      return manager.validateGrant(grant)
+    })
+    .then((grant) => t.notEqual(grant.access_token, undefined))
+})
+
 test('GrantManager should be able to validate invalid iat', (t) => {
   t.plan(1)
   manager.obtainDirectly('test-user', 'tiger')


### PR DESCRIPTION
…realm URL

This issue is encountered when working with a backend system that is on a different domain than the domain that issues the KeyCloak certificate or for systems that want to keep the certification request internal to their own network while the certificate issuer is on a public network

closes #308

