### PR TITLE
Implement 'allowed-issuers' config option

### DIFF
--- a/keycloak.d.ts
+++ b/keycloak.d.ts
@@ -23,6 +23,7 @@ declare namespace KeycloakConnect {
     'resource': string
     'ssl-required': string
     'bearer-only'?: boolean
+    'allowed-issuers'?: string[]|string
     realm: string
   }
 

--- a/middleware/auth-utils/config.js
+++ b/middleware/auth-utils/config.js
@@ -131,6 +131,16 @@ Config.prototype.configure = function configure (config) {
   this.realmUrl = this.authServerUrl + '/realms/' + this.realm
 
   /**
+   * Acceptable values for the `iss` Issuer claim in the JWT token.
+   * If not set, the token issuer is validated against the realm URL.
+   * @type {String[]}
+   */
+  this.allowedIssuers = resolveValue(config['allowed-issuers']) || [this.realmUrl]
+  if (typeof this.allowedIssuers === 'string') {
+    this.allowedIssuers = [this.allowedIssuers]
+  }
+
+  /**
    * Root realm admin URL.
    * @type {String} */
   this.realmAdminUrl = this.authServerUrl + '/admin/realms/' + this.realm

--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -41,6 +41,7 @@ function GrantManager (config) {
   this.notBefore = 0
   this.rotation = new Rotation(config)
   this.verifyTokenAudience = config.verifyTokenAudience
+  this.allowedIssuers = config.allowedIssuers
 }
 
 /**
@@ -425,7 +426,7 @@ GrantManager.prototype.validateToken = function validateToken (token, expectedTy
       reject(new Error('invalid token (wrong type)'))
     } else if (token.content.iat < this.notBefore) {
       reject(new Error('invalid token (stale token)'))
-    } else if (token.content.iss !== this.realmUrl) {
+    } else if (!this.allowedIssuers.includes(token.content.iss)) {
       reject(new Error('invalid token (wrong ISS)'))
     } else {
       const audienceData = Array.isArray(token.content.aud) ? token.content.aud : [token.content.aud]

--- a/test/fixtures/auth-utils/keycloak-frontend-url.json
+++ b/test/fixtures/auth-utils/keycloak-frontend-url.json
@@ -1,0 +1,11 @@
+{
+  "server-url": "http://localhost:8080",
+  "realm": "nodejs-test",
+  "min-time-between-jwks-requests": 0,
+  "resource": "confidential-client",
+  "secret": "62b8de48-672e-4287-bb1e-6af39aec045e",
+  "allowed-issuers": ["http://10.0.2.2:8080/auth/realms/nodejs-test"],
+  "bearerOnly": true,
+  "public-client": false,
+  "verify-token-audience": true
+}

--- a/test/grant-manager-spec.mjs
+++ b/test/grant-manager-spec.mjs
@@ -532,6 +532,19 @@ test('GrantManager should be able to validate invalid ISS', (t) => {
     })
 })
 
+test('GrantManager should be able to validate overridden ISS', (t) => {
+  const frontendManager = getManager('./test/fixtures/auth-utils/keycloak-frontend-url.json')
+  manager.obtainDirectly('test-user', 'tiger')
+    .then((grant) => {
+      grant.access_token.content.iss = 'http://10.0.2.2:8080/auth/realms/nodejs-test'
+      return frontendManager.validateGrant(grant)
+    })
+    .then((grant) => {
+      t.notEqual(grant, undefined)
+    })
+    .then(t.end)
+})
+
 test('GrantManager should be able to validate invalid iat', (t) => {
   t.plan(1)
   manager.obtainDirectly('test-user', 'tiger')

--- a/test/unit/hconfig-test.mjs
+++ b/test/unit/hconfig-test.mjs
@@ -45,6 +45,21 @@ test('Config#configure with env variable reference set with fallback', (t) => {
   t.end()
 })
 
+test('Config#configure with iss variable set iss', (t) => {
+  const iss = 'http://10.0.2.2:8080/auth/realms/realm'
+  const cfg = new Config({ 'allowed-issuers': [iss] })
+
+  t.deepEqual(cfg.allowedIssuers, [iss])
+  t.end()
+})
+
+test('Config#configure without iss variable fallback to realmUrl', (t) => {
+  const cfg = new Config({ authServerUrl: 'http://localhost:8080/auth', realm: '${env.USER}' })
+
+  t.deepEqual(cfg.allowedIssuers, [cfg.realmUrl])
+  t.end()
+})
+
 test('Config#configure with realm-public-key', (t) => {
   t.plan(2)
   RSA.generateKeypair(2048, 65537, { public: true, pem: true }, (err, keyz) => {


### PR DESCRIPTION
Allows overriding 'iss' claim validation with different URLs.

Based on #294, but changed to allow multiple different allowed issuers.

Closes #294
Closes #597 - similar PR, but only one issuer.
Fixes #308